### PR TITLE
Remove unused 501-specific helper

### DIFF
--- a/game_501.cpp
+++ b/game_501.cpp
@@ -70,8 +70,3 @@ void resetirajIgru_501() {
     trenutniIgrac = 0;
     Serial.println("Igra 501 je resetirana.");
 }
-
-void sljedeciIgrac_501() {
-    trenutniIgrac = (trenutniIgrac + 1) % brojIgraca;
-    Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
-}

--- a/game_501.h
+++ b/game_501.h
@@ -4,4 +4,3 @@
 void inicijalizirajIgru_501();
 void obradiPogodak_501(const String& nazivMete);
 void resetirajIgru_501();
-void sljedeciIgrac_501();


### PR DESCRIPTION
## Summary
- remove `sljedeciIgrac_501` declaration and implementation
- rely on the generic `sljedeciIgrac()` instead

## Testing
- `dmesg | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687d03d191d08328a2d305f7a0491e29