### PR TITLE
Define bounce out rule flag

### DIFF
--- a/config.h
+++ b/config.h
@@ -14,3 +14,4 @@ constexpr int THRESHOLD_PROMASAJ = 600;
 // Pravila igre
 extern bool DOUBLE_OUT;
 extern bool DOUBLE_IN;
+extern bool BOUNCE_OUT;

--- a/game.cpp
+++ b/game.cpp
@@ -11,6 +11,7 @@
 
 bool DOUBLE_IN = false;
 bool DOUBLE_OUT = false;
+bool BOUNCE_OUT = false;
 
 Igrac igraci[6];
 int brojIgraca = 0;


### PR DESCRIPTION
## Summary
- expose `BOUNCE_OUT` flag in `config.h`
- set default value in `game.cpp`

## Testing
- `g++ -c game_301.cpp -o /tmp/game_301.o` *(fails: `Arduino.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d0eed6e148328b361e5a856f79ba2