### PR TITLE
Make bounce-out rule constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 
 Neka pravila igre se definiraju preko tipki ili u `config.h`:
 
-- `BOUNCE_OUT` – kada je `true`, prelazak ispod nule poništava potez
 - `DOUBLE_OUT` – kada je `true`, igru je moguće završiti samo Double poljem
 - `DOUBLE_IN` – kada je `true`, igrač mora započeti pogodak s Double da bi bodovi vrijedili
+
+Pravilo *bounce-out* (bust) u igrama **301** i **501** uvijek je aktivno i nije potrebno posebno podešavanje.
 
 ---
 

--- a/config.h
+++ b/config.h
@@ -12,5 +12,6 @@ constexpr uint8_t PIN_MIKROFON = A0;
 constexpr int THRESHOLD_PROMASAJ = 600;
 
 // Pravila igre
+constexpr bool BOUNCE_OUT = true;
 extern bool DOUBLE_OUT;
 extern bool DOUBLE_IN;


### PR DESCRIPTION
## Summary
- enforce bounce-out rule at compile time with `constexpr`
- document that bounce-out is always active for 301/501 games

## Testing
- `g++ -c game.cpp` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d118fb71c8328bea6b5d4817656e7