### PR TITLE
Add NEW PLAYER handling and per-round logic

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -15,6 +15,7 @@ void setup() {
   inicijalizirajTipke();
   inicijalizirajZaruljice();
   inicijalizirajMete();
+  pinMode(PIN_BUZZER, OUTPUT);
 
   Serial.println("Dobrodošli u PIKADO aparat!");
 
@@ -63,9 +64,28 @@ void loop() {
     inicijalizirajIgrace(odabraniBrojIgraca);
     aktivnaIgra = static_cast<TipIgre>(odabranaIgra);
     pokreniAktivnuIgru();
+    igraZavrsena = false;
 
     // Glavna igračka petlja
-    while (true) {
+    while (!igraZavrsena) {
+      ocitajTipke();
+      if (tipkaStisnuta(IGRA_RESET)) {
+        resetirajAktivnuIgru();
+        odabranaIgra = -1;
+        odabraniBrojIgraca = -1;
+        igraZavrsena = true;
+        break;
+      }
+
+      if (cekanjeNovogIgraca) {
+        if (tipkaStisnuta(IGRA_NEW_PLAYER)) {
+          sljedeciIgrac();
+          cekanjeNovogIgraca = false;
+        }
+        delay(10);
+        continue;
+      }
+
       String pogodak = detektirajZonu(); // funkcija iz detection.cpp
       if (pogodak != "") {
         obradiPogodak(pogodak);
@@ -73,6 +93,24 @@ void loop() {
 
       detektirajPromasaj(); // ako postoji implementacija
       delay(10);
+    }
+
+    // Čekaj da korisnik pokrene novu igru
+    while (igraZavrsena) {
+      ocitajTipke();
+      if (tipkaStisnuta(IGRA_RESET)) {
+        resetirajAktivnuIgru();
+        odabranaIgra = -1;
+        odabraniBrojIgraca = -1;
+        break;
+      }
+      if (tipkaStisnuta(IGRA_NEW_PLAYER)) {
+        resetirajAktivnuIgru();
+        inicijalizirajIgrace(odabraniBrojIgraca);
+        pokreniAktivnuIgru();
+        igraZavrsena = false;
+      }
+      delay(50);
     }
   }
 

--- a/config.h
+++ b/config.h
@@ -15,3 +15,6 @@ constexpr int THRESHOLD_PROMASAJ = 600;
 constexpr bool BOUNCE_OUT = true;
 extern bool DOUBLE_OUT;
 extern bool DOUBLE_IN;
+
+// Pin za buzzer koji svira pobjednicki ton
+constexpr uint8_t PIN_BUZZER = 8;

--- a/game.cpp
+++ b/game.cpp
@@ -16,6 +16,9 @@ Igrac igraci[6];
 int brojIgraca = 0;
 int trenutniIgrac = 0;
 TipIgre aktivnaIgra = Igra_301;
+bool igraZavrsena = false;
+bool cekanjeNovogIgraca = false;
+uint8_t brojStrelica = 0;
 
 void inicijalizirajIgrace(int broj) {
     brojIgraca = constrain(broj, 1, 6);
@@ -30,6 +33,12 @@ void inicijalizirajIgrace(int broj) {
 void sljedeciIgrac() {
     trenutniIgrac = (trenutniIgrac + 1) % brojIgraca;
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+}
+
+void krajPoteza() {
+    cekanjeNovogIgraca = true;
+    brojStrelica = 0;
+    Serial.println("Izvadi strelice i pritisni NEW PLAYER.");
 }
 
 void pokreniAktivnuIgru() {
@@ -55,5 +64,24 @@ void obradiPogodak(const String& nazivMete) {
         case Igra_Scram:    obradiPogodak_scram(nazivMete); break;
         case Igra_Cricket:  obradiPogodak_cricket(nazivMete); break;
         case Igra_3Inline:  obradiPogodak_3inline(nazivMete); break;
+    }
+}
+
+void zavrsiIgru() {
+    igraZavrsena = true;
+    tone(PIN_BUZZER, 1000, 500);  // kratki zvuk kao signal pobjede
+    Serial.println("Igra završena. Pritisni NEW PLAYER ili RESET za novu igru.");
+}
+
+void resetirajAktivnuIgru() {
+    switch (aktivnaIgra) {
+        case Igra_301:      resetirajIgru_301(); break;
+        case Igra_501:      resetirajIgru_501(); break;
+        case Igra_Shanghai: resetirajIgru_shanghai(); break;
+        case Igra_Hangman:  resetirajIgru_hangman(); break;
+        case Igra_Roulette: resetirajIgru_roulette(); break;
+        case Igra_Scram:    resetirajIgru_scram(); break;
+        case Igra_Cricket:  resetirajIgru_cricket(); break;
+        case Igra_3Inline:  resetirajIgru_3inline(); break;
     }
 }

--- a/game.h
+++ b/game.h
@@ -23,6 +23,16 @@ extern Igrac igraci[6];
 extern int brojIgraca;
 extern int trenutniIgrac;
 extern TipIgre aktivnaIgra;
+extern bool igraZavrsena;
+extern bool cekanjeNovogIgraca;
+extern uint8_t brojStrelica;
+
+void krajPoteza();
+
+// Zavrsi igru i odsviraj ton na buzzeru
+void zavrsiIgru();
+// Resetira trenutno aktivnu igru
+void resetirajAktivnuIgru();
 
 void inicijalizirajIgrace(int broj);
 void sljedeciIgrac();

--- a/game_301.cpp
+++ b/game_301.cpp
@@ -28,7 +28,7 @@ void obradiPogodak_301(const String& nazivMete) {
     if (DOUBLE_IN && !igrac.jeAktiviran) {
         if (!nazivMete.startsWith("Double")) {
             Serial.println("Double IN: pogodak ne vrijedi jer nije Double.");
-            sljedeciIgrac();
+            krajPoteza();
             return;
         }
         igrac.jeAktiviran = true;
@@ -47,7 +47,7 @@ void obradiPogodak_301(const String& nazivMete) {
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
         Serial.println("Bust! Prelazak preko 0 nije dozvoljen.");
         igrac.bodovi = igrac.prethodniBodovi;
-        sljedeciIgrac();
+        krajPoteza();
         return;
     }
 
@@ -55,22 +55,26 @@ void obradiPogodak_301(const String& nazivMete) {
         if (DOUBLE_OUT) {
             if (nazivMete.startsWith("Double")) {
                 Serial.println(igrac.ime + " je pobijedio!");
-                // ovdje možeš završiti igru
+                zavrsiIgru();
             } else {
                 Serial.println("Završetak mora biti s Double!");
                 igrac.bodovi = igrac.prethodniBodovi;
-                sljedeciIgrac();
+                krajPoteza();
             }
         } else {
             Serial.println(igrac.ime + " je pobijedio!");
-            // ovdje možeš završiti igru
+            zavrsiIgru();
         }
         return;
     }
 
     igrac.bodovi = bodoviNakonPogotka;
     Serial.println(igrac.ime + ": " + String(igrac.bodovi) + " bodova");
-    sljedeciIgrac();
+
+    brojStrelica++;
+    if (brojStrelica >= 3) {
+        krajPoteza();
+    }
 }
 
 

--- a/game_3inline.cpp
+++ b/game_3inline.cpp
@@ -50,6 +50,7 @@ void obradiPogodak_3inline(const String& nazivMete) {
             uzastopni++;
             if (uzastopni >= 3) {
                 Serial.println(igrac.ime + " je pobijedio s 3 uzastopna broja!");
+                zavrsiIgru();
                 return; // kraj igre
             }
         } else {

--- a/game_501.cpp
+++ b/game_501.cpp
@@ -28,7 +28,7 @@ void obradiPogodak_501(const String& nazivMete) {
     if (DOUBLE_IN && !igrac.jeAktiviran) {
         if (!nazivMete.startsWith("Double")) {
             Serial.println("Double IN: pogodak ne vrijedi jer nije Double.");
-            sljedeciIgrac();
+            krajPoteza();
             return;
         }
         igrac.jeAktiviran = true;
@@ -47,7 +47,7 @@ void obradiPogodak_501(const String& nazivMete) {
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
         Serial.println("Bust! Prelazak preko 0 nije dozvoljen.");
         igrac.bodovi = igrac.prethodniBodovi;
-        sljedeciIgrac();
+        krajPoteza();
         return;
     }
 
@@ -55,22 +55,26 @@ void obradiPogodak_501(const String& nazivMete) {
         if (DOUBLE_OUT) {
             if (nazivMete.startsWith("Double")) {
                 Serial.println(igrac.ime + " je pobijedio!");
-                // ovdje možeš završiti igru
+                zavrsiIgru();
             } else {
                 Serial.println("Završetak mora biti s Double!");
                 igrac.bodovi = igrac.prethodniBodovi;
-                sljedeciIgrac();
+                krajPoteza();
             }
         } else {
             Serial.println(igrac.ime + " je pobijedio!");
-            // ovdje možeš završiti igru
+            zavrsiIgru();
         }
         return;
     }
 
     igrac.bodovi = bodoviNakonPogotka;
     Serial.println(igrac.ime + ": " + String(igrac.bodovi) + " bodova");
-    sljedeciIgrac();
+
+    brojStrelica++;
+    if (brojStrelica >= 3) {
+        krajPoteza();
+    }
 }
 
 void resetirajIgru_501() {

--- a/game_cricket.cpp
+++ b/game_cricket.cpp
@@ -97,6 +97,7 @@ void obradiPogodak_cricket(const String& nazivMete) {
         if (vodi) {
             Serial.println("Igrač " + igraci[trenutniIgrac].ime + " je zatvorio sve brojeve i vodi u bodovima!");
             Serial.println("POBJEDA!");
+            zavrsiIgru();
             return;
         }
     }

--- a/game_hangman.cpp
+++ b/game_hangman.cpp
@@ -88,6 +88,7 @@ void sljedeciIgrac_hangman() {
     if (pobjednik != -1) {
         Serial.println("Pobjednik je IGRAČ " + String(pobjednik) + "!");
     }
+    zavrsiIgru();
 }
 
 void resetirajIgru_hangman() {

--- a/game_roulette.cpp
+++ b/game_roulette.cpp
@@ -68,6 +68,7 @@ void obradiPogodak_roulette(const String& nazivMete) {
                     }
                 }
                 Serial.println("Pobjednik je IGRAČ " + String(pobjednik) + "!");
+                zavrsiIgru();
                 return;
             }
 

--- a/game_scram.cpp
+++ b/game_scram.cpp
@@ -97,6 +97,7 @@ void obradiPogodak_scram(const String& nazivMete) {
                         Serial.println("Pobjednik je IGRAČ 1!");
                     else
                         Serial.println("Neriješeno!");
+                    zavrsiIgru();
                     return;
                 }
             } else {

--- a/game_shanghai.cpp
+++ b/game_shanghai.cpp
@@ -63,6 +63,7 @@ void obradiPogodak_shanghai(const String& nazivMete) {
             pogodjenoDouble[trenutniIgrac] &&
             pogodjenoTriple[trenutniIgrac]) {
             Serial.println(igraci[trenutniIgrac].ime + " je napravio SHANGHAI i pobijedio!");
+            zavrsiIgru();
             return; // završava igra
         }
 
@@ -90,6 +91,7 @@ void obradiPogodak_shanghai(const String& nazivMete) {
                     }
                 }
                 Serial.println("Pobjednik je " + igraci[pobjednik].ime + "!");
+                zavrsiIgru();
                 return;
             } else {
                 Serial.print("Runda "); Serial.print(runda);


### PR DESCRIPTION
## Summary
- track dart throws and wait for NEW PLAYER between turns
- differentiate NEW PLAYER vs RESET in main loop
- implement 3-dart rounds in games 301 and 501
- expose `krajPoteza`, `cekanjeNovogIgraca` and `brojStrelica`

## Testing
- `g++ -fsyntax-only -std=c++11 *.cpp PIKADO.ino` *(fails: `Arduino.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d135579a08328af3dbd6eab7d514a