### PR TITLE
Add placeholder melody module

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -4,6 +4,7 @@
 #include "buttons.h"
 #include "zaruljice.h"
 #include "game.h"
+#include "melodies.h"
 
 // Definicija globalnih varijabli za odabir
 int odabranaIgra = -1;
@@ -53,6 +54,7 @@ void setup() {
   pinMode(PIN_BUZZER, OUTPUT);
 
   Serial.println("Dobrodošli u PIKADO aparat!");
+  svirajUvodnuMelodiju();
 
   // Test žaruljica
   for (int i = 0; i < 2; i++) {

--- a/melodies.cpp
+++ b/melodies.cpp
@@ -1,0 +1,54 @@
+#include "melodies.h"
+#include "config.h"
+
+static void pusti(const Ton* melodija, size_t duljina) {
+    for (size_t i = 0; i < duljina; ++i) {
+        if (melodija[i].frekvencija == 0) {
+            delay(melodija[i].trajanje);
+        } else {
+            tone(PIN_BUZZER, melodija[i].frekvencija, melodija[i].trajanje);
+            delay(static_cast<unsigned long>(melodija[i].trajanje * 1.3));
+        }
+    }
+    noTone(PIN_BUZZER);
+}
+
+void svirajMelodiju(const Ton* melodija, size_t duljina) { pusti(melodija, duljina); }
+
+// ----------------------- Definicije melodija -----------------------
+
+static const Ton introMelody[] = {
+    {NOTE_C4, 150}, {NOTE_E4, 150}, {NOTE_G4, 300}
+};
+
+void svirajUvodnuMelodiju() { pusti(introMelody, sizeof(introMelody) / sizeof(Ton)); }
+
+static const Ton zvukBacanje[] = {
+    {NOTE_A4, 100}, {0, 50}, {NOTE_A4, 100}
+};
+void svirajZvukBacanja() { pusti(zvukBacanje, sizeof(zvukBacanje) / sizeof(Ton)); }
+
+static const Ton zvukPromasaj[] = {
+    {NOTE_C4, 200}, {NOTE_B4, 400}
+};
+void svirajZvukPromasaja() { pusti(zvukPromasaj, sizeof(zvukPromasaj) / sizeof(Ton)); }
+
+static const Ton zvukVadenje[] = {
+    {NOTE_G4, 150}, {NOTE_E4, 150}
+};
+void svirajZvukVadenja() { pusti(zvukVadenje, sizeof(zvukVadenje) / sizeof(Ton)); }
+
+static const Ton zvukNoviIgrac[] = {
+    {NOTE_D4, 150}, {NOTE_G4, 300}
+};
+void svirajZvukNovogIgraca() { pusti(zvukNoviIgrac, sizeof(zvukNoviIgrac) / sizeof(Ton)); }
+
+static const Ton zvukPobjeda[] = {
+    {NOTE_G4, 150}, {NOTE_A4, 150}, {NOTE_B4, 150}, {NOTE_C5, 300}
+};
+void svirajZvukPobjede() { pusti(zvukPobjeda, sizeof(zvukPobjeda) / sizeof(Ton)); }
+
+static const Ton zvukTipka[] = {
+    {NOTE_E4, 100}
+};
+void svirajZvukTipke() { pusti(zvukTipka, sizeof(zvukTipka) / sizeof(Ton)); }

--- a/melodies.h
+++ b/melodies.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <Arduino.h>
+#include "notes.h"
+
+struct Ton {
+    uint16_t frekvencija; // Hz, 0 = pauza
+    uint16_t trajanje;    // trajanje u milisekundama
+};
+
+void svirajMelodiju(const Ton* melodija, size_t duljina);
+
+void svirajUvodnuMelodiju();
+void svirajZvukBacanja();
+void svirajZvukPromasaja();
+void svirajZvukVadenja();
+void svirajZvukNovogIgraca();
+void svirajZvukPobjede();
+void svirajZvukTipke();

--- a/notes.h
+++ b/notes.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <Arduino.h>
+
+// Jednostavna lista nota i njihovih frekvencija (Hz)
+constexpr uint16_t NOTE_C4 = 262;
+constexpr uint16_t NOTE_D4 = 294;
+constexpr uint16_t NOTE_E4 = 330;
+constexpr uint16_t NOTE_F4 = 349;
+constexpr uint16_t NOTE_G4 = 392;
+constexpr uint16_t NOTE_A4 = 440;
+constexpr uint16_t NOTE_B4 = 494;
+constexpr uint16_t NOTE_C5 = 523;


### PR DESCRIPTION
## Summary
- define basic note frequencies in `notes.h`
- create melody helper API with default sounds in `melodies.cpp/h`
- include new melody system in the main sketch and play an intro tune on start

## Testing
- `apt-get update`
- `apt-get install -y avr-libc gcc-avr`
- `g++ -c melodies.cpp -I. -std=c++17` *(fails: `avr/pgmspace.h` missing)*
- `avr-g++ -c melodies.cpp -I. -std=c++17` *(fails: `binary.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e613918fc8328b1b3eb878f2234bc