### PR TITLE
Add MAX7219 scoreboard support

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -5,6 +5,7 @@
 #include "zaruljice.h"
 #include "game.h"
 #include "melodies.h"
+#include "scoreboard.h"
 
 // Definicija globalnih varijabli za odabir
 int odabranaIgra = -1;
@@ -51,6 +52,7 @@ void setup() {
   inicijalizirajTipke();
   inicijalizirajZaruljice();
   inicijalizirajMete();
+  inicijalizirajDisplay();
   pinMode(PIN_BUZZER, OUTPUT);
 
   Serial.println("Dobrodošli u PIKADO aparat!");

--- a/game.cpp
+++ b/game.cpp
@@ -9,6 +9,7 @@
 #include "game_3inline.h"
 #include "config.h"
 #include "melodies.h"
+#include "scoreboard.h"
 
 bool DOUBLE_IN = false;
 bool DOUBLE_OUT = false;
@@ -29,6 +30,7 @@ void inicijalizirajIgrace(int broj) {
         igraci[i].prethodniBodovi = 0;
     }
     trenutniIgrac = 0;
+    ocistiDisplay();
 }
 
 void sljedeciIgrac() {

--- a/game_301.cpp
+++ b/game_301.cpp
@@ -1,6 +1,7 @@
 #include "game_301.h"
 #include "game.h"
 #include "config.h"
+#include "scoreboard.h"
 
 int vrijednostMete(const String& naziv) {
     if (naziv.startsWith("Triple ")) return 3 * naziv.substring(7).toInt();
@@ -18,6 +19,7 @@ void inicijalizirajIgru_301() {
     trenutniIgrac = 0;
     Serial.println("Igra 301 započinje!");
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+    osvjeziSveBodove();
 }
 
 void obradiPogodak_301(const String& nazivMete) {
@@ -47,6 +49,7 @@ void obradiPogodak_301(const String& nazivMete) {
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
         Serial.println("Bust! Prelazak preko 0 nije dozvoljen.");
         igrac.bodovi = igrac.prethodniBodovi;
+        prikaziBodove(trenutniIgrac, igrac.bodovi);
         krajPoteza();
         return;
     }
@@ -65,11 +68,13 @@ void obradiPogodak_301(const String& nazivMete) {
             Serial.println(igrac.ime + " je pobijedio!");
             zavrsiIgru();
         }
+        prikaziBodove(trenutniIgrac, igrac.bodovi);
         return;
     }
 
     igrac.bodovi = bodoviNakonPogotka;
     Serial.println(igrac.ime + ": " + String(igrac.bodovi) + " bodova");
+    prikaziBodove(trenutniIgrac, igrac.bodovi);
 
     brojStrelica++;
     if (brojStrelica >= 3) {
@@ -85,4 +90,5 @@ void resetirajIgru_301() {
     }
     trenutniIgrac = 0;
     Serial.println("Igra je resetirana.");
+    osvjeziSveBodove();
 }

--- a/game_501.cpp
+++ b/game_501.cpp
@@ -1,6 +1,7 @@
 #include "game_501.h"
 #include "game.h"
 #include "config.h"
+#include "scoreboard.h"
 
 int vrijednostMete_501(const String& naziv) {
     if (naziv.startsWith("Triple ")) return 3 * naziv.substring(7).toInt();
@@ -18,6 +19,7 @@ void inicijalizirajIgru_501() {
     trenutniIgrac = 0;
     Serial.println("Igra 501 započinje!");
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+    osvjeziSveBodove();
 }
 
 void obradiPogodak_501(const String& nazivMete) {
@@ -47,6 +49,7 @@ void obradiPogodak_501(const String& nazivMete) {
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
         Serial.println("Bust! Prelazak preko 0 nije dozvoljen.");
         igrac.bodovi = igrac.prethodniBodovi;
+        prikaziBodove(trenutniIgrac, igrac.bodovi);
         krajPoteza();
         return;
     }
@@ -65,11 +68,13 @@ void obradiPogodak_501(const String& nazivMete) {
             Serial.println(igrac.ime + " je pobijedio!");
             zavrsiIgru();
         }
+        prikaziBodove(trenutniIgrac, igrac.bodovi);
         return;
     }
 
     igrac.bodovi = bodoviNakonPogotka;
     Serial.println(igrac.ime + ": " + String(igrac.bodovi) + " bodova");
+    prikaziBodove(trenutniIgrac, igrac.bodovi);
 
     brojStrelica++;
     if (brojStrelica >= 3) {
@@ -84,4 +89,5 @@ void resetirajIgru_501() {
     }
     trenutniIgrac = 0;
     Serial.println("Igra 501 je resetirana.");
+    osvjeziSveBodove();
 }

--- a/scoreboard.cpp
+++ b/scoreboard.cpp
@@ -1,0 +1,46 @@
+#include "scoreboard.h"
+#include "game.h"
+#include <LedControl.h>
+
+const uint8_t PIN_DIN = 9;
+const uint8_t PIN_CLK = 10;
+const uint8_t PIN_CS  = 11;
+const uint8_t BROJ_DISPLEJA = 6;
+
+static LedControl lc(PIN_DIN, PIN_CLK, PIN_CS, BROJ_DISPLEJA);
+
+void inicijalizirajDisplay() {
+    for (uint8_t i = 0; i < BROJ_DISPLEJA; i++) {
+        lc.shutdown(i, false);
+        lc.setIntensity(i, 8);
+        lc.clearDisplay(i);
+    }
+}
+
+static void prikaziBroj(uint8_t modul, int broj) {
+    if (modul >= BROJ_DISPLEJA) return;
+    broj = constrain(broj, 0, 999);
+    int stotine  = broj / 100;
+    int desetice = (broj / 10) % 10;
+    int jedinice = broj % 10;
+
+    lc.setDigit(modul, 2, jedinice, false);
+    lc.setDigit(modul, 1, desetice, false);
+    lc.setDigit(modul, 0, stotine, false);
+}
+
+void prikaziBodove(uint8_t igrac, int bodovi) {
+    prikaziBroj(igrac, bodovi);
+}
+
+void osvjeziSveBodove() {
+    for (int i = 0; i < brojIgraca; i++) {
+        prikaziBodove(i, igraci[i].bodovi);
+    }
+}
+
+void ocistiDisplay() {
+    for (uint8_t i = 0; i < BROJ_DISPLEJA; i++) {
+        lc.clearDisplay(i);
+    }
+}

--- a/scoreboard.h
+++ b/scoreboard.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <Arduino.h>
+
+void inicijalizirajDisplay();
+void prikaziBodove(uint8_t igrac, int bodovi);
+void osvjeziSveBodove();
+void ocistiDisplay();


### PR DESCRIPTION
## Summary
- add new `scoreboard` module for 3-digit MAX7219 displays
- init displays from `setup()`
- clear displays when initializing players
- show and refresh scores in `301` and `501` games

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e694c2a2c832897cf299811843921