### PR TITLE
Enable MAX7219 scoring for all games

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 - Modularna struktura igara
 - Double IN i Double OUT kao opcionalna pravila
 - Serijski ispis rezultata i poruka
+- Prikaz bodova na MAX7219 displayu za sve igre
 
 ---
 
@@ -39,6 +40,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 - Mikrofon spojen na A0
 - Tipke za odabir spojene na digitalne pinove (pull-up)
 - LED žaruljice upravljane preko UCN5821 (shift register)
+- Segmentni display s MAX7219 za prikaz bodova
 
 ---
 

--- a/game_cricket.cpp
+++ b/game_cricket.cpp
@@ -1,6 +1,7 @@
 #include "game_cricket.h"
 #include "game.h"
 #include "config.h"
+#include "scoreboard.h"
 
 const int BROJEVI[7] = {15, 16, 17, 18, 19, 20, 25}; // validni brojevi
 int pogodci[6][7];   // [igrač][broj index]
@@ -10,11 +11,13 @@ void inicijalizirajIgru_cricket() {
     for (int i = 0; i < brojIgraca; i++) {
         for (int j = 0; j < 7; j++) pogodci[i][j] = 0;
         bodoviCricket[i] = 0;
+        igraci[i].bodovi = 0;
     }
     trenutniIgrac = 0;
     Serial.println("Igra CRICKET započinje!");
     Serial.println("Pogađaj brojeve 15–20 i bull (25).");
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+    osvjeziSveBodove();
 }
 
 int indeksBroja(int broj) {
@@ -66,8 +69,10 @@ void obradiPogodak_cricket(const String& nazivMete) {
 
         if (!sviZatvorili(idx)) {
             bodoviCricket[trenutniIgrac] += BROJEVI[idx] * visak;
+            igraci[trenutniIgrac].bodovi = bodoviCricket[trenutniIgrac];
             Serial.println("Višak pogodaka! +" + String(BROJEVI[idx] * visak) +
                            " bodova. Ukupno: " + String(bodoviCricket[trenutniIgrac]));
+            prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
         } else {
             Serial.println("Broj je već zatvoren za sve – nema bodova.");
         }

--- a/game_hangman.cpp
+++ b/game_hangman.cpp
@@ -1,6 +1,7 @@
 #include "game_hangman.h"
 #include "game.h"
 #include "config.h"
+#include "scoreboard.h"
 
 bool pogodjeniBrojevi[21];       // 1–20
 int greske[6];                  // broj grešaka po igraču
@@ -12,12 +13,14 @@ void inicijalizirajIgru_hangman() {
     for (int i = 0; i < brojIgraca; i++) {
         greske[i] = 0;
         bodoviHangman[i] = 0;
+        igraci[i].bodovi = 0;
     }
     trenutniIgrac = 0;
     Serial.println("Igra HANGMAN započinje!");
     Serial.println("Pogodi brojeve 1–20 bez ponavljanja.");
     Serial.println("Svaki igrač ima najviše 6 grešaka.");
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+    osvjeziSveBodove();
 }
 
 void obradiPogodak_hangman(const String& nazivMete) {
@@ -56,8 +59,10 @@ void obradiPogodak_hangman(const String& nazivMete) {
         pogodjeniBrojevi[broj] = true;
         int bodovi = broj * mnozitelj;
         bodoviHangman[trenutniIgrac] += bodovi;
+        igraci[trenutniIgrac].bodovi = bodoviHangman[trenutniIgrac];
         Serial.println("Pogođeno " + String(broj) + " × " + String(mnozitelj) +
                        " = +" + String(bodovi) + " bodova (Ukupno: " + String(bodoviHangman[trenutniIgrac]) + ")");
+        prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
     }
 
     sljedeciIgrac_hangman();

--- a/game_roulette.cpp
+++ b/game_roulette.cpp
@@ -1,6 +1,7 @@
 #include "game_roulette.h"
 #include "game.h"
 #include "config.h"
+#include "scoreboard.h"
 
 int runda = 1;
 int strelica = 1;
@@ -13,11 +14,13 @@ void inicijalizirajIgru_roulette() {
     for (int i = 0; i < brojIgraca; i++) {
         ciljaniBroj[i] = random(1, 21);  // 1–20
         bodoviRoulette[i] = 0;
+        igraci[i].bodovi = 0;
         Serial.println("Igrač " + String(i) + " ciljani broj: " + String(ciljaniBroj[i]));
     }
     trenutniIgrac = 0;
     Serial.println("Igra ROULETTE započinje!");
     Serial.println("Runda 1 – Na potezu: " + igraci[trenutniIgrac].ime);
+    osvjeziSveBodove();
 }
 
 void obradiPogodak_roulette(const String& nazivMete) {
@@ -40,8 +43,10 @@ void obradiPogodak_roulette(const String& nazivMete) {
 
     if (broj == ciljaniBroj[trenutniIgrac]) {
         bodoviRoulette[trenutniIgrac] += broj * mnozitelj;
+        igraci[trenutniIgrac].bodovi = bodoviRoulette[trenutniIgrac];
         Serial.println("Pogođen vlastiti broj! +" + String(broj * mnozitelj) +
                        " bodova. Ukupno: " + String(bodoviRoulette[trenutniIgrac]));
+        prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
     } else {
         Serial.println("Promašaj – nije tvoj broj.");
     }

--- a/game_scram.cpp
+++ b/game_scram.cpp
@@ -1,6 +1,7 @@
 #include "game_scram.h"
 #include "game.h"
 #include "config.h"
+#include "scoreboard.h"
 
 int faza = 1;
 bool zakljucaniBrojevi[21];  // 1–20
@@ -15,11 +16,14 @@ void inicijalizirajIgru_scram() {
     for (int i = 1; i <= 20; i++) zakljucaniBrojevi[i] = false;
     bodovi[0] = 0;
     bodovi[1] = 0;
+    igraci[0].bodovi = 0;
+    igraci[1].bodovi = 0;
 
     Serial.println("Igra SCRAM (faza 1):");
     Serial.println("Igrač 0 je BLOCKER – pokušava zaključati sve brojeve.");
     Serial.println("Igrač 1 je SCORER – skuplja bodove.");
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+    osvjeziSveBodove();
 }
 
 void obradiPogodak_scram(const String& nazivMete) {
@@ -71,8 +75,10 @@ void obradiPogodak_scram(const String& nazivMete) {
         else {
             if (!zakljucaniBrojevi[broj]) {
                 bodovi[1] += broj * mnozitelj;
+                igraci[1].bodovi = bodovi[1];
                 Serial.println("SCORER pogodio " + String(broj) + " × " + String(mnozitelj) +
                                " = +" + String(broj * mnozitelj) + " bodova. (Ukupno: " + String(bodovi[1]) + ")");
+                prikaziBodove(1, igraci[1].bodovi);
             } else {
                 Serial.println("Broj " + String(broj) + " je zaključan – nema bodova.");
             }
@@ -108,8 +114,10 @@ void obradiPogodak_scram(const String& nazivMete) {
         else {
             if (!zakljucaniBrojevi[broj]) {
                 bodovi[0] += broj * mnozitelj;
+                igraci[0].bodovi = bodovi[0];
                 Serial.println("SCORER pogodio " + String(broj) + " × " + String(mnozitelj) +
                                " = +" + String(broj * mnozitelj) + " bodova. (Ukupno: " + String(bodovi[0]) + ")");
+                prikaziBodove(0, igraci[0].bodovi);
             } else {
                 Serial.println("Broj " + String(broj) + " je zaključan – nema bodova.");
             }

--- a/game_shanghai.cpp
+++ b/game_shanghai.cpp
@@ -1,6 +1,7 @@
 #include "game_shanghai.h"
 #include "game.h"
 #include "config.h"
+#include "scoreboard.h"
 
 int runda = 1;
 int strelica = 1;
@@ -17,12 +18,14 @@ void inicijalizirajIgru_shanghai() {
         pogodjenoSimple[i] = false;
         pogodjenoDouble[i] = false;
         pogodjenoTriple[i] = false;
+        igraci[i].bodovi = 0;
     }
     trenutniIgrac = 0;
     Serial.println("Igra SHANGHAI započinje!");
     Serial.print("Runda "); Serial.print(runda);
     Serial.println(": Pogađa se broj " + String(runda));
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+    osvjeziSveBodove();
 }
 
 void obradiPogodak_shanghai(const String& nazivMete) {
@@ -47,6 +50,8 @@ void obradiPogodak_shanghai(const String& nazivMete) {
         Serial.println("Promašaj! Važeći broj u ovoj rundi je " + String(runda));
     } else {
         bodoviPoIgracu[trenutniIgrac] += broj * mnozitelj;
+        igraci[trenutniIgrac].bodovi = bodoviPoIgracu[trenutniIgrac];
+        prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
         if (mnozitelj == 1) pogodjenoSimple[trenutniIgrac] = true;
         if (mnozitelj == 2) pogodjenoDouble[trenutniIgrac] = true;
         if (mnozitelj == 3) pogodjenoTriple[trenutniIgrac] = true;


### PR DESCRIPTION
## Summary
- integrate scoreboard display into Cricket, Shanghai, Hangman, Scram and Roulette
- document MAX7219 segment display in the README

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_687e6bc4d5308328b53db5684fce5d23