### PR TITLE
Update scoreboard to show dashes for unused players

### DIFF
--- a/scoreboard.cpp
+++ b/scoreboard.cpp
@@ -17,6 +17,13 @@ void inicijalizirajDisplay() {
     }
 }
 
+static void prikaziCrte(uint8_t modul) {
+    if (modul >= BROJ_DISPLEJA) return;
+    for (uint8_t pos = 0; pos < 3; pos++) {
+        lc.setChar(modul, pos, '-', false);
+    }
+}
+
 static void prikaziBroj(uint8_t modul, int broj) {
     if (modul >= BROJ_DISPLEJA) return;
     broj = constrain(broj, 0, 999);
@@ -37,10 +44,13 @@ void osvjeziSveBodove() {
     for (int i = 0; i < brojIgraca; i++) {
         prikaziBodove(i, igraci[i].bodovi);
     }
+    for (int i = brojIgraca; i < BROJ_DISPLEJA; i++) {
+        prikaziCrte(i);
+    }
 }
 
 void ocistiDisplay() {
     for (uint8_t i = 0; i < BROJ_DISPLEJA; i++) {
-        lc.clearDisplay(i);
+        prikaziCrte(i);
     }
 }

--- a/scoreboard.h
+++ b/scoreboard.h
@@ -4,4 +4,5 @@
 void inicijalizirajDisplay();
 void prikaziBodove(uint8_t igrac, int bodovi);
 void osvjeziSveBodove();
+// Postavlja sve module na prikaz "---"
 void ocistiDisplay();


### PR DESCRIPTION
## Summary
- display `---` on all MAX7219 modules when clearing the scoreboard
- keep unused modules showing dashes when fewer than six players are active
- document the new behaviour in `scoreboard.h`

## Testing
- `g++ -c scoreboard.cpp` *(fails: Arduino.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6de69a348328ad7e70d058efe850