### PR TITLE
Implement miss detection using microphone

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 ## ⚙️ Funkcionalnosti
 
 - Detekcija svih zona na ploči (Simple, Double, Triple)
-- Detekcija promašaja pomoću mikrofona
+- Detekcija promašaja pomoću mikrofona (svaki promašaj se broji kao bačena strelica)
 - Tipke za odabir igre, broja igrača i pravila
 - LED indikacija za sve odabire
 - Modularna struktura igara
@@ -36,7 +36,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 
 - **Arduino Mega 2560**
 - Dart ploča spojena na digitalne i analogne pinove
-- Mikrofon spojen na A0
+- Mikrofon spojen na A0 za detekciju promašaja (granična vrijednost je `THRESHOLD_PROMASAJ` iz `config.h`)
 - Tipke za odabir spojene na digitalne pinove (pull-up)
 - LED žaruljice upravljane preko UCN5821 (shift register)
 - Segmentni display s MAX7219 (6 modula) za prikaz bodova

--- a/detection.cpp
+++ b/detection.cpp
@@ -1,6 +1,7 @@
 #include "detection.h"
 #include "config.h"
 #include "melodies.h"
+#include "game.h"
 
 // Struktura za metu
 struct Meta {
@@ -85,10 +86,21 @@ String detektirajZonu() {
 }
 
 void detektirajPromasaj() {
-  int vrijednost = analogRead(PIN_MIKROFON);
-  if (vrijednost > THRESHOLD_PROMASAJ) {
+  static unsigned long zadnjeVrijeme = 0;
+  int zbroj = 0;
+  for (int i = 0; i < 3; i++) {
+    zbroj += analogRead(PIN_MIKROFON);
+    delay(1);
+  }
+  int vrijednost = zbroj / 3;
+
+  if (vrijednost > THRESHOLD_PROMASAJ && millis() - zadnjeVrijeme > 300) {
     Serial.println("Promašaj detektiran!");
     svirajZvukPromasaja();
-    delay(500);
+    brojStrelica++;
+    if (brojStrelica >= 3) {
+      krajPoteza();
+    }
+    zadnjeVrijeme = millis();
   }
 }


### PR DESCRIPTION
## Summary
- include `game.h` in `detection.cpp`
- count darts and end turn when a miss is detected
- debounce microphone signal to avoid duplicate detections
- document microphone threshold in README

## Testing
- `g++ -std=c++17 -I . -c detection.cpp` *(fails: avr/pgmspace.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f44d877e883288d3b126a998c139f