### PR TITLE
Add personalized player audio

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -151,6 +151,7 @@ void loop() {
     brojStrelica = 0;
     igraZavrsena = false;
     svirajZvukBacanja();
+    svirajImeIgraca(trenutniIgrac);
 
     // Glavna igračka petlja
     while (!igraZavrsena) {

--- a/game.cpp
+++ b/game.cpp
@@ -36,7 +36,7 @@ void inicijalizirajIgrace(int broj) {
 void sljedeciIgrac() {
     trenutniIgrac = (trenutniIgrac + 1) % brojIgraca;
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
-    svirajZvukNovogIgraca();
+    svirajImeIgraca(trenutniIgrac);
 }
 
 void krajPoteza() {

--- a/melodies.cpp
+++ b/melodies.cpp
@@ -13,3 +13,9 @@ void svirajZvukVadenja() { mp3.play(4); }
 void svirajZvukNovogIgraca() { mp3.play(5); }
 void svirajZvukPobjede() { mp3.play(6); }
 void svirajZvukTipke() { mp3.play(7); }
+
+void svirajImeIgraca(uint8_t index) {
+    if (index < 6) {
+        mp3.play(20 + index);
+    }
+}

--- a/melodies.h
+++ b/melodies.h
@@ -9,3 +9,5 @@ void svirajZvukVadenja();
 void svirajZvukNovogIgraca();
 void svirajZvukPobjede();
 void svirajZvukTipke();
+// Pusti MP3 datoteku sa snimljenim imenom igrača (0-5)
+void svirajImeIgraca(uint8_t index);


### PR DESCRIPTION
## Summary
- define `svirajImeIgraca` to play a track for a specific player
- announce the current player with their audio clip when their turn starts
- trigger player audio at game start

## Testing
- `g++ -std=c++11 -I. -c melodies.cpp -o /tmp/melodies.o` *(fails: avr/pgmspace.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f5a14eda083289017b05dc478de25