### PR TITLE
Blink NEW_PLAYER LED after three throws

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -40,6 +40,18 @@ void osvjeziZaruljiceIgra() {
     stanjeZaruljica[idxIgraca] = true;
   }
 
+  // Treperi lampica NEW_PLAYER dok se čekaju izbačene strelice
+  if (cekanjeNovogIgraca) {
+    unsigned long sada = millis();
+    if (sada - zadnjeBlinkanje > 500) {
+      zadnjeBlinkanje = sada;
+      blinkStanje = !blinkStanje;
+    }
+    stanjeZaruljica[IGRA_NEW_PLAYER] = blinkStanje;
+  } else {
+    stanjeZaruljica[IGRA_NEW_PLAYER] = false;
+  }
+
   // Prikaži odabrane DOUBLE IN/OUT opcije
   stanjeZaruljica[OSTALO_IN_CUTTHROAT] = DOUBLE_IN;
   stanjeZaruljica[OSTALO_OUT_TEAM] = DOUBLE_OUT;


### PR DESCRIPTION
## Summary
- blink the NEW_PLAYER lamp when waiting for the next player
- keep the lamp off during normal play

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f5fe13d8c8328893dabffa65e0d45