### PR TITLE
Set faster LED transitions

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -97,7 +97,7 @@ void loop() {
     }
 
     unsigned long sada = millis();
-    if (sada - zadnjeMijenjanje > 1000) {
+    if (sada - zadnjeMijenjanje > 500) {
       zadnjeMijenjanje = sada;
       indeksIgre = (indeksIgre + 1) % 8;
     }
@@ -126,7 +126,7 @@ void loop() {
     }
 
     unsigned long sada = millis();
-    if (sada - zadnjeMijenjanje > 1000) {
+    if (sada - zadnjeMijenjanje > 500) {
       zadnjeMijenjanje = sada;
       indeksIgraca = (indeksIgraca + 1) % 6;
     }


### PR DESCRIPTION
## Summary
- shorten wait time before switching game/player selection LEDs from 1s to 500ms

## Testing
- `g++ -o test PIKADO.ino` *(fails: file format not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687f61fc76788328bd0ab057357d0265