### PR TITLE
Add warning sound for early dart throws

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -105,6 +105,10 @@ void loop() {
     for (int i = 0; i < 18; i++) stanjeZaruljica[i] = false;
     stanjeZaruljica[redoslijedIgara[indeksIgre]] = true;
     postaviZaruljice(stanjeZaruljica);
+    if (detektirajBacanjeBezIgre()) {
+      Serial.println("Bacena strelica prije odabira igre!");
+      svirajZvukNepostavljenaIgra();
+    }
     delay(50);
     return;
   }
@@ -137,6 +141,10 @@ void loop() {
     stanjeZaruljica[OSTALO_IN_CUTTHROAT] = doubleInOdabran;
     stanjeZaruljica[OSTALO_OUT_TEAM] = doubleOutOdabran;
     postaviZaruljice(stanjeZaruljica);
+    if (detektirajBacanjeBezIgre()) {
+      Serial.println("Bacena strelica prije odabira igraca!");
+      svirajZvukNepostavljenaIgra();
+    }
     delay(50);
     return;
   }

--- a/detection.cpp
+++ b/detection.cpp
@@ -104,3 +104,26 @@ void detektirajPromasaj() {
     zadnjeVrijeme = millis();
   }
 }
+
+bool detektirajBacanjeBezIgre() {
+  // Provjera pogođene mete
+  if (scanForHit() != nullptr) {
+    return true;
+  }
+
+  // Provjera promašaja preko mikrofona
+  static unsigned long zadnjeVrijeme = 0;
+  int zbroj = 0;
+  for (int i = 0; i < 3; i++) {
+    zbroj += analogRead(PIN_MIKROFON);
+    delay(1);
+  }
+  int vrijednost = zbroj / 3;
+
+  if (vrijednost > THRESHOLD_PROMASAJ && millis() - zadnjeVrijeme > 300) {
+    zadnjeVrijeme = millis();
+    return true;
+  }
+
+  return false;
+}

--- a/detection.h
+++ b/detection.h
@@ -4,3 +4,4 @@
 void inicijalizirajMete();
 void detektirajPromasaj();
 String detektirajZonu();
+bool detektirajBacanjeBezIgre();

--- a/melodies.cpp
+++ b/melodies.cpp
@@ -13,6 +13,7 @@ void svirajZvukVadenja() { mp3.play(4); }
 void svirajZvukNovogIgraca() { mp3.play(5); }
 void svirajZvukPobjede() { mp3.play(6); }
 void svirajZvukTipke() { mp3.play(7); }
+void svirajZvukNepostavljenaIgra() { mp3.play(8); }
 
 void svirajImeIgraca(uint8_t index) {
     if (index < 6) {

--- a/melodies.h
+++ b/melodies.h
@@ -9,5 +9,6 @@ void svirajZvukVadenja();
 void svirajZvukNovogIgraca();
 void svirajZvukPobjede();
 void svirajZvukTipke();
+void svirajZvukNepostavljenaIgra();
 // Pusti MP3 datoteku sa snimljenim imenom igrača (0-5)
 void svirajImeIgraca(uint8_t index);


### PR DESCRIPTION
## Summary
- detect dart throws even when game/player selection isn't done
- add new sound `svirajZvukNepostavljenaIgra()`
- play warning sound if a dart is thrown before selecting game or players

## Testing
- `g++ -std=c++17 -I. -c buttons.cpp` *(fails: `avr/pgmspace.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8f6b32588328994e79b8bccc5768