### PR TITLE
Add Bust sound to countdown games

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Datoteke moraju imati prefiks s četiri znamenke kako bi odgovarale numeraciji `
 | 6    | `0006.mp3`      | Pobjednička melodija    |
 | 7    | `0007.mp3`      | Zvuk pritiska tipke     |
 | 8    | `0008.mp3`      | Upozorenje nepostavljene igre |
+| 9    | `0009.mp3`      | Zvuk "Bust" (prelazak preko 0) |
 | 21   | `0021.mp3`      | Snimka "Igrač 1"        |
 | 22   | `0022.mp3`      | Snimka "Igrač 2"        |
 | 23   | `0023.mp3`      | Snimka "Igrač 3"        |

--- a/game_301.cpp
+++ b/game_301.cpp
@@ -48,6 +48,7 @@ void obradiPogodak_301(const String& nazivMete) {
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
         Serial.println("Bust! Prelazak preko 0 nije dozvoljen.");
+        svirajZvukBust();
         igrac.bodovi = igrac.prethodniBodovi;
         prikaziBodove(trenutniIgrac, igrac.bodovi);
         krajPoteza();

--- a/game_501.cpp
+++ b/game_501.cpp
@@ -48,6 +48,7 @@ void obradiPogodak_501(const String& nazivMete) {
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
         Serial.println("Bust! Prelazak preko 0 nije dozvoljen.");
+        svirajZvukBust();
         igrac.bodovi = igrac.prethodniBodovi;
         prikaziBodove(trenutniIgrac, igrac.bodovi);
         krajPoteza();

--- a/game_701.cpp
+++ b/game_701.cpp
@@ -48,6 +48,7 @@ void obradiPogodak_701(const String& nazivMete) {
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
         Serial.println("Bust! Prelazak preko 0 nije dozvoljen.");
+        svirajZvukBust();
         igrac.bodovi = igrac.prethodniBodovi;
         prikaziBodove(trenutniIgrac, igrac.bodovi);
         krajPoteza();

--- a/melodies.cpp
+++ b/melodies.cpp
@@ -13,6 +13,7 @@ void svirajZvukVadenja() { mp3.play(4); }
 void svirajZvukPobjede() { mp3.play(6); }
 void svirajZvukTipke() { mp3.play(7); }
 void svirajZvukNepostavljenaIgra() { mp3.play(8); }
+void svirajZvukBust() { mp3.play(9); }
 
 void svirajImeIgraca(uint8_t index) {
     if (index < 6) {

--- a/melodies.h
+++ b/melodies.h
@@ -9,5 +9,6 @@ void svirajZvukVadenja();
 void svirajZvukPobjede();
 void svirajZvukTipke();
 void svirajZvukNepostavljenaIgra();
+void svirajZvukBust();
 // Pusti MP3 datoteku sa snimljenim imenom igrača (0-5)
 void svirajImeIgraca(uint8_t index);


### PR DESCRIPTION
## Summary
- add `svirajZvukBust` function in `melodies` module
- update README with new `0009.mp3` file description
- play bust sound in 301/501/701 when bust occurs

## Testing
- `g++ -c game.cpp -I.` *(fails: fatal error: avr/pgmspace.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6880926244a88328afd6a0533463c096