### PR TITLE
Fix duplicate variable definitions

### DIFF
--- a/game_3inline.cpp
+++ b/game_3inline.cpp
@@ -2,7 +2,7 @@
 #include "game.h"
 #include "config.h"
 
-bool pogodci[6][21]; // [igrač][broj 1-20], indeks 0 se ne koristi
+static bool pogodci[6][21]; // [igrač][broj 1-20], indeks 0 se ne koristi
 
 void inicijalizirajIgru_3inline() {
     for (int i = 0; i < brojIgraca; i++) {

--- a/game_cricket.cpp
+++ b/game_cricket.cpp
@@ -4,8 +4,8 @@
 #include "scoreboard.h"
 
 const int BROJEVI[7] = {15, 16, 17, 18, 19, 20, 25}; // validni brojevi
-int pogodci[6][7];   // [igrač][broj index]
-int bodoviCricket[6];
+static int pogodci[6][7];   // [igrač][broj index]
+static int bodoviCricket[6];
 
 void inicijalizirajIgru_cricket() {
     for (int i = 0; i < brojIgraca; i++) {

--- a/game_roulette.cpp
+++ b/game_roulette.cpp
@@ -3,8 +3,8 @@
 #include "config.h"
 #include "scoreboard.h"
 
-int runda = 1;
-int strelica = 1;
+static int runda = 1;
+static int strelica = 1;
 int ciljaniBroj[6];  // ciljani broj po igraču
 int bodoviRoulette[6];  // ukupni bodovi
 

--- a/game_shanghai.cpp
+++ b/game_shanghai.cpp
@@ -3,8 +3,8 @@
 #include "config.h"
 #include "scoreboard.h"
 
-int runda = 1;
-int strelica = 1;
+static int runda = 1;
+static int strelica = 1;
 int bodoviPoIgracu[6];
 bool pogodjenoSimple[6];
 bool pogodjenoDouble[6];


### PR DESCRIPTION
## Summary
- mark global arrays/vars in game modules as `static` to avoid duplicate symbols when linking

## Testing
- `g++ -std=c++11 -I. -c game_3inline.cpp -o /tmp/game_3inline.o` *(fails: `avr/pgmspace.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68809713acc0832899445571ca986cac