### PR TITLE
Add audio callouts for dartboard hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 - Prikaz bodova na MAX7219 displayu za sve igre
 - Prepoznaje bacanje strelice prije odabira igre ili igrača i pušta zvuk upozorenja
 - Snimljeni glasovni pozivi igrača ("Igrač 1", "Igrač 2"...)
+- Glasovna najava pogođenog polja (koristi mp3 datoteke od `0100.mp3` nadalje)
 - Automatski prelazak u "sleep" način rada nakon 10 minuta neaktivnosti (display blinka svakih 5 s)
 
 ---

--- a/detection.cpp
+++ b/detection.cpp
@@ -78,11 +78,13 @@ static const Meta* scanForHit() {
 
 
 String detektirajZonu() {
-  const Meta* pogodjena = scanForHit();
-  if (pogodjena) {
-    registrirajInterakciju();
-    return String(pogodjena->naziv);
-  }
+    const Meta* pogodjena = scanForHit();
+    if (pogodjena) {
+        registrirajInterakciju();
+        String naziv = String(pogodjena->naziv);
+        svirajZvukMete(naziv);
+        return naziv;
+    }
   return String("");
 }
 

--- a/melodies.cpp
+++ b/melodies.cpp
@@ -20,3 +20,40 @@ void svirajImeIgraca(uint8_t index) {
         mp3.play(20 + index);
     }
 }
+
+struct ZvukMeta { const char* naziv; uint16_t index; };
+
+static const ZvukMeta zvukoviMeta[] = {
+    {"Triple 17", 100}, {"Double 17", 101}, {"Simple 17", 102},
+    {"Triple 3", 103},  {"Double 3", 104},  {"Simple 3", 105},
+    {"Triple 19", 106}, {"Double 19", 107}, {"Simple 19", 108},
+    {"Triple 7", 109},  {"Double 7", 110},  {"Simple 7", 111},
+    {"Triple 16", 112}, {"Double 16", 113}, {"Simple 16", 114},
+    {"Triple 6", 115},  {"Double 6", 116},  {"Simple 6", 117},
+    {"Triple 10",118},  {"Double 10",119}, {"Simple 10",120},
+    {"Triple 15",121}, {"Double 15",122}, {"Simple 15",123},
+    {"Triple 2",124},  {"Double 2",125},  {"Simple 2",126},
+    {"25 (Double)",127},
+    {"Triple 13",128}, {"Double 13",129}, {"Simple 13",130},
+    {"Triple 8",131},  {"Double 8",132},  {"Simple 8",133},
+    {"Triple 14",134}, {"Double 14",135}, {"Simple 14",136},
+    {"Triple 9",137},  {"Double 9",138},  {"Simple 9",139},
+    {"Triple 11",140},{"Double 11",141},{"Simple 11",142},
+    {"Triple 12",143},{"Double 12",144},{"Simple 12",145},
+    {"Triple 5",146}, {"Double 5",147}, {"Simple 5",148},
+    {"Triple 20",149},{"Double 20",150},{"Simple 20",151},
+    {"Triple 1",152}, {"Double 1",153}, {"Simple 1",154},
+    {"Triple 18",155},{"Double 18",156},{"Simple 18",157},
+    {"Triple 4",158}, {"Double 4",159},
+    {"25 (Simple)",160},
+    {"Simple 4",161}
+};
+
+void svirajZvukMete(const String& nazivMete) {
+    for (const auto& zvuk : zvukoviMeta) {
+        if (nazivMete == zvuk.naziv) {
+            mp3.play(zvuk.index);
+            return;
+        }
+    }
+}

--- a/melodies.h
+++ b/melodies.h
@@ -12,3 +12,5 @@ void svirajZvukNepostavljenaIgra();
 void svirajZvukBust();
 // Pusti MP3 datoteku sa snimljenim imenom igrača (0-5)
 void svirajImeIgraca(uint8_t index);
+// Reproduciraj najavu pogođene mete
+void svirajZvukMete(const String& nazivMete);


### PR DESCRIPTION
## Summary
- announce the hit target with a matching MP3 file
- expose new `svirajZvukMete` API in `melodies`
- hook detection logic to trigger the sound
- mention hit callouts in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68809d4277a48328af603ce28d07994e