### PR TITLE
Remove throw sound function

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -223,7 +223,6 @@ void loop() {
     cekanjeNovogIgraca = false;
     brojStrelica = 0;
     igraZavrsena = false;
-    svirajZvukBacanja();
     svirajImeIgraca(trenutniIgrac);
 
     // Glavna igračka petlja

--- a/game.cpp
+++ b/game.cpp
@@ -60,7 +60,6 @@ void pokreniAktivnuIgru() {
 }
 
 void obradiPogodak(const String& nazivMete) {
-    svirajZvukBacanja();
     switch (aktivnaIgra) {
         case Igra_301:      obradiPogodak_301(nazivMete); break;
         case Igra_501:      obradiPogodak_501(nazivMete); break;

--- a/melodies.cpp
+++ b/melodies.cpp
@@ -7,7 +7,6 @@ static JQ6500 mp3(Serial1);
 void inicijalizirajZvuk() { mp3.begin(); }
 
 void svirajUvodnuMelodiju() { mp3.play(1); }
-void svirajZvukBacanja() { mp3.play(2); }
 void svirajZvukPromasaja() { mp3.play(3); }
 void svirajZvukVadenja() { mp3.play(4); }
 void svirajZvukPobjede() { mp3.play(6); }

--- a/melodies.h
+++ b/melodies.h
@@ -3,7 +3,6 @@
 
 void inicijalizirajZvuk();
 void svirajUvodnuMelodiju();
-void svirajZvukBacanja();
 void svirajZvukPromasaja();
 void svirajZvukVadenja();
 void svirajZvukPobjede();


### PR DESCRIPTION
## Summary
- clean up sound API: delete `svirajZvukBacanja`
- drop all references to the removed function
- rely on `svirajZvukMete` to play hit sounds

## Testing
- `avr-g++ -std=c++17 -I. -I/usr/share/arduino/hardware/arduino/avr/cores/arduino -c game.cpp` *(fails: itoa.h: No such file or directory)*
- `avr-g++ -std=c++17 -x c++ -I. -I/usr/share/arduino/hardware/arduino/avr/cores/arduino -c PIKADO.ino` *(fails: itoa.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68810abbdbb08328bbb6a9eabc90afb9