### PR TITLE
Show target on scoreboard

### DIFF
--- a/game_roulette.cpp
+++ b/game_roulette.cpp
@@ -20,6 +20,7 @@ void inicijalizirajIgru_roulette() {
     trenutniIgrac = 0;
     Serial.println("Igra ROULETTE započinje!");
     Serial.println("Runda 1 – Na potezu: " + igraci[trenutniIgrac].ime);
+    prikaziCilj(trenutniIgrac, ciljaniBroj[trenutniIgrac], 1500);
     osvjeziSveBodove();
 }
 
@@ -81,6 +82,7 @@ void obradiPogodak_roulette(const String& nazivMete) {
         }
 
         Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
+        prikaziCilj(trenutniIgrac, ciljaniBroj[trenutniIgrac], 1500);
     }
 }
 

--- a/game_shanghai.cpp
+++ b/game_shanghai.cpp
@@ -24,6 +24,7 @@ void inicijalizirajIgru_shanghai() {
     Serial.println("Igra SHANGHAI započinje!");
     Serial.print("Runda "); Serial.print(runda);
     Serial.println(": Pogađa se broj " + String(runda));
+    prikaziCilj(trenutniIgrac, runda, 1500);
     Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -101,6 +102,7 @@ void obradiPogodak_shanghai(const String& nazivMete) {
             } else {
                 Serial.print("Runda "); Serial.print(runda);
                 Serial.println(": Pogađa se broj " + String(runda));
+                prikaziCilj(trenutniIgrac, runda, 1500);
             }
         }
 

--- a/scoreboard.cpp
+++ b/scoreboard.cpp
@@ -55,6 +55,12 @@ void ocistiDisplay() {
     }
 }
 
+void prikaziCilj(uint8_t igrac, int broj, unsigned long trajanjeMs) {
+    prikaziBroj(igrac, broj);
+    delay(trajanjeMs);
+    prikaziBodove(igrac, igraci[igrac].bodovi);
+}
+
 void ugasiDisplay() {
     for (uint8_t i = 0; i < BROJ_DISPLEJA; i++) {
         lc.clearDisplay(i);

--- a/scoreboard.h
+++ b/scoreboard.h
@@ -6,5 +6,7 @@ void prikaziBodove(uint8_t igrac, int bodovi);
 void osvjeziSveBodove();
 // Postavlja sve module na prikaz "---"
 void ocistiDisplay();
+// Privremeno prikaži ciljani broj na displayu igraca
+void prikaziCilj(uint8_t igrac, int broj, unsigned long trajanjeMs);
 // Gasi sve segmente na svim modulima
 void ugasiDisplay();


### PR DESCRIPTION
## Summary
- display round/turn target on players' scoreboard
- implement `prikaziCilj` helper for temporary target display
- show Shanghai round number on the active player's display
- show Roulette player's secret number at the start of each turn

## Testing
- `g++ -c scoreboard.cpp -I .` *(fails: `avr/pgmspace.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881e8f145c48328a9c12be770dad708