### PR TITLE
Add 3-inline progress display

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 - Double IN i Double OUT kao opcionalna pravila
 - Serijski ispis rezultata i poruka
 - Prikaz bodova na MAX7219 displayu za sve igre
+- U igri **3-in-line** display prikazuje duljinu trenutnog niza pogodaka, a novi rekord blinka
 - Prepoznaje bacanje strelice prije odabira igre ili igrača i pušta zvuk upozorenja
 - Snimljeni glasovni pozivi igrača ("Igrač 1", "Igrač 2"...)
 - Glasovna najava pogođenog polja (koristi mp3 datoteke od `0100.mp3` nadalje)

--- a/scoreboard.cpp
+++ b/scoreboard.cpp
@@ -66,3 +66,14 @@ void ugasiDisplay() {
         lc.clearDisplay(i);
     }
 }
+
+void blinkBroj(uint8_t modul, int broj, uint8_t ponavljanja, unsigned int trajanjeMs) {
+    if (modul >= BROJ_DISPLEJA) return;
+    for (uint8_t i = 0; i < ponavljanja; i++) {
+        prikaziBroj(modul, broj);
+        delay(trajanjeMs);
+        lc.clearDisplay(modul);
+        delay(trajanjeMs);
+    }
+    prikaziBroj(modul, broj);
+}

--- a/scoreboard.h
+++ b/scoreboard.h
@@ -10,3 +10,5 @@ void ocistiDisplay();
 void prikaziCilj(uint8_t igrac, int broj, unsigned long trajanjeMs);
 // Gasi sve segmente na svim modulima
 void ugasiDisplay();
+// Blinka zadani broj na odabranom modulu
+void blinkBroj(uint8_t igrac, int broj, uint8_t ponavljanja, unsigned int trajanjeMs);


### PR DESCRIPTION
## Summary
- blink digits on MAX7219 modules
- track longest streak in 3-inline game and display it
- document new 3-inline progress indicator

## Testing
- `g++ -I. -c game_3inline.cpp scoreboard.cpp` *(fails: avr/pgmspace.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6881ef75abec83289b257e37b02badab