### PR TITLE
Add roulette voice prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Datoteke moraju imati prefiks s četiri znamenke kako bi odgovarale numeraciji `
 | 24   | `0024.mp3`      | Snimka "Igrač 4"        |
 | 25   | `0025.mp3`      | Snimka "Igrač 5"        |
 | 26   | `0026.mp3`      | Snimka "Igrač 6"        |
+| 30   | `0030.mp3`      | "Roulette start"        |
+| 31   | `0031.mp3`      | "Target is" najava      |
+| 32   | `0032.mp3`      | "Target hit"            |
+| 33   | `0033.mp3`      | "Roulette over"         |
 
 ### Datoteke za pojedinacne mete
 

--- a/game_roulette.cpp
+++ b/game_roulette.cpp
@@ -2,6 +2,7 @@
 #include "game.h"
 #include "config.h"
 #include "scoreboard.h"
+#include "melodies.h"
 
 static int runda = 1;
 static int strelica = 1;
@@ -19,8 +20,10 @@ void inicijalizirajIgru_roulette() {
     }
     trenutniIgrac = 0;
     Serial.println("Igra ROULETTE započinje!");
+    svirajZvukRouletteStart();
     Serial.println("Runda 1 – Na potezu: " + igraci[trenutniIgrac].ime);
     prikaziCilj(trenutniIgrac, ciljaniBroj[trenutniIgrac], 1500);
+    najaviCiljaniBroj(ciljaniBroj[trenutniIgrac]);
     osvjeziSveBodove();
 }
 
@@ -48,8 +51,10 @@ void obradiPogodak_roulette(const String& nazivMete) {
         Serial.println("Pogođen vlastiti broj! +" + String(broj * mnozitelj) +
                        " bodova. Ukupno: " + String(bodoviRoulette[trenutniIgrac]));
         prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
+        svirajZvukTargetHit();
     } else {
         Serial.println("Promašaj – nije tvoj broj.");
+        svirajZvukPromasaja();
     }
 
     strelica++;
@@ -64,6 +69,7 @@ void obradiPogodak_roulette(const String& nazivMete) {
 
             if (runda > 5) {
                 Serial.println("Kraj igre ROULETTE!");
+                svirajZvukRouletteOver();
                 int pobjednik = 0;
                 int najvise = bodoviRoulette[0];
                 for (int i = 0; i < brojIgraca; i++) {
@@ -83,6 +89,7 @@ void obradiPogodak_roulette(const String& nazivMete) {
 
         Serial.println("Na potezu: " + igraci[trenutniIgrac].ime);
         prikaziCilj(trenutniIgrac, ciljaniBroj[trenutniIgrac], 1500);
+        najaviCiljaniBroj(ciljaniBroj[trenutniIgrac]);
     }
 }
 

--- a/melodies.cpp
+++ b/melodies.cpp
@@ -56,3 +56,15 @@ void svirajZvukMete(const String& nazivMete) {
         }
     }
 }
+
+void svirajZvukRouletteStart() { mp3.play(30); }
+
+void najaviCiljaniBroj(int broj) {
+    mp3.play(31);
+    delay(700);
+    svirajZvukMete("Simple " + String(broj));
+}
+
+void svirajZvukTargetHit() { mp3.play(32); }
+
+void svirajZvukRouletteOver() { mp3.play(33); }

--- a/melodies.h
+++ b/melodies.h
@@ -13,3 +13,7 @@ void svirajZvukBust();
 void svirajImeIgraca(uint8_t index);
 // Reproduciraj najavu pogođene mete
 void svirajZvukMete(const String& nazivMete);
+void svirajZvukRouletteStart();
+void najaviCiljaniBroj(int broj);
+void svirajZvukTargetHit();
+void svirajZvukRouletteOver();


### PR DESCRIPTION
## Summary
- expand audio API with roulette voice prompts
- announce targets and play result sounds in the Roulette game
- document new MP3 files for roulette in README

## Testing
- `g++ -c game_roulette.cpp melodies.cpp game.cpp scoreboard.cpp detection.cpp buttons.cpp zaruljice.cpp -I. >/tmp/build.log && tail -n 20 /tmp/build.log` *(fails: `avr/pgmspace.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881fe957d988328abc49a3dba37b669