### PR TITLE
Update docs for I2C pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,12 @@ Ova datoteka opisuje uloge (agents) unutar sustava elektroničkog pikada, kako b
 
 ---
 
-## 📺 6. Display Agent (`scoreboard.cpp`)
+## 📺 6. Display Agent (`scoreboard.cpp`, `lcd_display.cpp`)
 
-- **Odgovornost:** Prikaz bodova i statusa na segmentnim LED displayima
-- **Tehnologija:** MAX7219, LedControl ili MD_MAX72XX
+- **Odgovornost:** Prikaz bodova i statusa na segmentnim LED displayima i LCD-u
+- **Tehnologija:** MAX7219, LedControl ili MD_MAX72XX za LED display,
+  LiquidCrystal_I2C za LCD
+- **Pinovi:** LCD koristi I2C konekciju (SDA=20, SCL=21) pa ti pinovi moraju biti slobodni
 - **Prikaz:** Bodovi svakog igrača, status igre, redoslijed
 
 ---

--- a/POVEZIVANJE_I_MP3.md
+++ b/POVEZIVANJE_I_MP3.md
@@ -4,6 +4,9 @@ Sadržaj README datoteke koji opisuje raspored pinova na ploči i nazive MP3 dat
 
 ## 🪛 Povezivanje
 
+Napomena: pinovi **20** (SDA) i **21** (SCL) rezervirani su za I2C vezu s LCD
+ekranom te se ne smiju koristiti za tipke ili druge periferije.
+
 ### Tipke (gumbi)
 
 | Pinovi | Funkcija         |
@@ -27,6 +30,14 @@ Sadržaj README datoteke koji opisuje raspored pinova na ploči i nazive MP3 dat
 | 9   | DIN      |
 | 10  | CLK      |
 | 11  | CS       |
+
+### LCD (I2C)
+
+| Pin | Funkcija |
+|-----|----------|
+| 20  | SDA      |
+| 21  | SCL      |
+|     | I2C adresa 0x27 |
 
 ### Pikado ploča (detekcija)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 - LED žaruljice upravljane preko UCN5821 (shift register)
 - Segmentni display s MAX7219 (6 modula) za prikaz bodova
 - JQ6500 MP3 modul za zvučne efekte (povezan na Serial1)
+- LCD preko I2C na pinovima SDA=20 i SCL=21
 
 ---
 

--- a/buttons.cpp
+++ b/buttons.cpp
@@ -1,5 +1,7 @@
 #include "buttons.h"
 
+// Pins 20 (SDA) and 21 (SCL) moraju ostati slobodni za I2C (LCD)
+// zato su tipke povezane tek od pina 22 nadalje
 const uint8_t pinoviTipki[BROJ_TIPKI] = {
   22, 23, 24, 25, 26, 27, 28, 29, 30, 31,  // IGRA
   32, 33, 34, 35, 36, 37,                 // IGRACI


### PR DESCRIPTION
## Summary
- clarify LCD is connected via I2C on pins 20/21
- document that I2C pins must remain unused by buttons
- update Display agent description
- note reserved pins directly in button code

## Testing
- `arduino-cli core install arduino:avr` *(fails: network unreachable)*
- `arduino-cli compile --fqbn arduino:avr:mega PIKADO.ino` *(fails: platform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688227b4aae08328a5ab8751883321b3