### PR TITLE
Add basic error handling with blinking RESET LED

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,14 @@ Ova datoteka opisuje uloge (agents) unutar sustava elektroničkog pikada, kako b
 
 ---
 
-## 🛠️ 10. Setup Agent (`PIKADO.ino`)
+## 🚨 10. Error Handler Agent (`error.cpp`)
+
+- **Odgovornost:** Centralizirano prijavljivanje i signaliziranje grešaka
+- **Indikacija:** blinkanje lampice tipke RESET dok je greška aktivna
+- **Koristi se:** `signalGreska()` za prijavu i `azurirajGresku()` u petlji
+
+---
+## 🛠️ 11. Setup Agent (`PIKADO.ino`)
 
 - **Odgovornost:** Glavni ulaz, inicijalizira sve agente
 - **Logika:** bira igru, broj igrača, pravila

--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -7,6 +7,7 @@
 #include "src/modules/melodies.h"
 #include "src/modules/scoreboard.h"
 #include "src/modules/lcd_display.h"
+#include "src/modules/error.h"
 
 // Definicija globalnih varijabli za odabir
 int odabranaIgra = -1;
@@ -70,6 +71,12 @@ void osvjeziZaruljiceIgra() {
   // Prikaži odabrane DOUBLE IN/OUT opcije
   stanjeZaruljica[OSTALO_IN_CUTTHROAT] = DOUBLE_IN;
   stanjeZaruljica[OSTALO_OUT_TEAM] = DOUBLE_OUT;
+
+  // Ako je aktivna greška, blinkaj RESET lampicom
+  azurirajGresku();
+  if (greskaAktivna()) {
+    stanjeZaruljica[IGRA_RESET] = greskaBlinkStanje();
+  }
 
   postaviZaruljice(stanjeZaruljica);
 }
@@ -195,6 +202,10 @@ void loop() {
       }
       stanjeZaruljica[OSTALO_IN_CUTTHROAT] = doubleInOdabran;
       stanjeZaruljica[OSTALO_OUT_TEAM] = doubleOutOdabran;
+    }
+    azurirajGresku();
+    if (greskaAktivna()) {
+      stanjeZaruljica[IGRA_RESET] = greskaBlinkStanje();
     }
     postaviZaruljice(stanjeZaruljica);
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Koristi mikrofon za detekciju promašaja i tipke za odabir igre, broja igrača i
 - Snimljeni glasovni pozivi igrača ("Igrač 1", "Igrač 2"...)
 - Glasovna najava pogođenog polja (koristi mp3 datoteke od `0100.mp3` nadalje)
 - Automatski prelazak u "sleep" način rada nakon 10 minuta neaktivnosti (display blinka svakih 5 s)
+- Signalizacija grešaka blinkanjem lampice tipke **RESET**
 
 ---
 
@@ -96,4 +97,8 @@ Za detaljniji opis toka igre pogledajte datoteku [TIJEK_IGARA.md](docs/TIJEK_IGA
 ## 📌 Napomena
 
 Ovaj sustav je dizajniran modularno tako da je lako dodavati nove igre i funkcionalnosti. Može se nadograditi s prikazom na OLED/TFT ili komunikacijom s Raspberry Pi.
+
+## ❗ Greške i signalizacija
+
+Greške se mogu prijaviti funkcijom `signalGreska()`. Dok je greška aktivna, lampica tipke **RESET** blinka kako bi korisnik znao da treba ponovno pokrenuti igru ili pregledati sustav.
 

--- a/src/modules/error.cpp
+++ b/src/modules/error.cpp
@@ -1,0 +1,31 @@
+#include "error.h"
+#include "lcd_display.h"
+
+static bool aktivna = false;
+static bool blinkStanje = false;
+static unsigned long zadnjeBlinkanje = 0;
+
+void signalGreska(const String &poruka) {
+    logPoruka(String("GRESKA: ") + poruka);
+    aktivna = true;
+    blinkStanje = true;
+    zadnjeBlinkanje = millis();
+}
+
+void obrisiGresku() {
+    aktivna = false;
+    blinkStanje = false;
+}
+
+bool greskaAktivna() { return aktivna; }
+
+bool greskaBlinkStanje() { return blinkStanje; }
+
+void azurirajGresku() {
+    if (!aktivna) return;
+    unsigned long sada = millis();
+    if (sada - zadnjeBlinkanje >= 500) {
+        zadnjeBlinkanje = sada;
+        blinkStanje = !blinkStanje;
+    }
+}

--- a/src/modules/error.h
+++ b/src/modules/error.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <Arduino.h>
+
+void signalGreska(const String &poruka);
+void obrisiGresku();
+void azurirajGresku();
+bool greskaAktivna();
+bool greskaBlinkStanje();


### PR DESCRIPTION
## Summary
- add `error.cpp` and `error.h` to signal errors
- blink the RESET LED when an error is active
- document new behaviour in README and AGENTS overview

## Testing
- `g++ -std=c++17 -I. -Isrc -x c++ -fsyntax-only PIKADO.ino src/modules/error.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6882356412848328a9a18129928bb055