### PR TITLE
Rename dartboard common pin constants

### DIFF
--- a/docs/CONNECTIONS_AND_MP3.md
+++ b/docs/CONNECTIONS_AND_MP3.md
@@ -41,7 +41,7 @@ Note: pins **20** (SDA) and **21** (SCL) are reserved for the LCD I2C bus and mu
 ### Dartboard (detection)
 
 - **Active sensor pins:** A4, A5, A6, A7, A8, A9, A10, A11, 53, 51, 49, 47, 45, 43, 41, 39
-- **Common pins:** A15 (`COM_45`), A14 (`COM_47`), A12 (`COM_A1`), A13 (`COM_A2`)
+- **Common pins:** A15 (`COM_A15`), A14 (`COM_A14`), A12 (`COM_A12`), A13 (`COM_A13`)
 - **Microphone for misses:** A0 (`PIN_MIKROFON`)
 
 ### JQ6500 MP3 module

--- a/docs/POVEZIVANJE_I_MP3.md
+++ b/docs/POVEZIVANJE_I_MP3.md
@@ -42,7 +42,7 @@ ekranom te se ne smiju koristiti za tipke ili druge periferije.
 ### Pikado ploča (detekcija)
 
 - **Aktivni pinovi senzora:** A4, A5, A6, A7, A8, A9, A10, A11, 53, 51, 49, 47, 45, 43, 41, 39
-- **Zajednički pinovi:** A15 (`COM_45`), A14 (`COM_47`), A12 (`COM_A1`), A13 (`COM_A2`)
+- **Zajednički pinovi:** A15 (`COM_A15`), A14 (`COM_A14`), A12 (`COM_A12`), A13 (`COM_A13`)
 - **Mikrofon za promašaje:** A0 (`PIN_MIKROFON`)
 
 ### JQ6500 MP3 modul

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -3,10 +3,10 @@
 
 // Zajednički pinovi
 // Novi raspored zajedničkih pinova nakon prenamjene ploče
-constexpr uint8_t COM_45 = A15;  // bijela žica
-constexpr uint8_t COM_47 = A14;  // crna žica
-constexpr uint8_t COM_A1 = A12;
-constexpr uint8_t COM_A2 = A13;
+constexpr uint8_t COM_A15 = A15;  // bijela žica
+constexpr uint8_t COM_A14 = A14;  // crna žica
+constexpr uint8_t COM_A12 = A12;
+constexpr uint8_t COM_A13 = A13;
 
 // Pin za mikrofon
 constexpr uint8_t PIN_MIKROFON = A0;

--- a/src/modules/detection.cpp
+++ b/src/modules/detection.cpp
@@ -13,36 +13,36 @@ struct Meta {
 
 // Definicija svih meta
 const Meta mete[] = {
-  // === Common 45 ===
-  {"Triple 17", A11, COM_45}, {"Double 17", A4, COM_45}, {"Simple 17", A5, COM_45},
-  {"Triple 3", A10, COM_45},  {"Double 3", 51, COM_45},  {"Simple 3", 53, COM_45},
-  {"Triple 19", A9, COM_45}, {"Double 19", 47, COM_45}, {"Simple 19", 49, COM_45},
-  {"Triple 7", A8, COM_45},  {"Double 7", 43, COM_45},   {"Simple 7", 45, COM_45},
-  {"Triple 16", A7, COM_45}, {"Double 16", 41, COM_45},  {"Simple 16", 39, COM_45},
+  // === Common A15 ===
+  {"Triple 17", A11, COM_A15}, {"Double 17", A4, COM_A15}, {"Simple 17", A5, COM_A15},
+  {"Triple 3", A10, COM_A15},  {"Double 3", 51, COM_A15},  {"Simple 3", 53, COM_A15},
+  {"Triple 19", A9, COM_A15}, {"Double 19", 47, COM_A15}, {"Simple 19", 49, COM_A15},
+  {"Triple 7", A8, COM_A15},  {"Double 7", 43, COM_A15},   {"Simple 7", 45, COM_A15},
+  {"Triple 16", A7, COM_A15}, {"Double 16", 41, COM_A15},  {"Simple 16", 39, COM_A15},
 
-  // === Common 47 ===
-  {"Triple 6", A10, COM_47},  {"Double 6", 51, COM_47},  {"Simple 6", 53, COM_47},
-  {"Triple 10", A9, COM_47}, {"Double 10", 47, COM_47}, {"Simple 10", 49, COM_47},
-  {"Triple 15", A8, COM_47}, {"Double 15", 43, COM_47},  {"Simple 15", 45, COM_47},
-  {"Triple 2", A7, COM_47},  {"Double 2", 41, COM_47},   {"Simple 2", 39, COM_47},
-  {"25 (Double)", A6, COM_47},
-  {"Triple 13", A11, COM_47}, {"Double 13", A4, COM_47}, {"Simple 13", A5, COM_47},
+  // === Common A14 ===
+  {"Triple 6", A10, COM_A14},  {"Double 6", 51, COM_A14},  {"Simple 6", 53, COM_A14},
+  {"Triple 10", A9, COM_A14}, {"Double 10", 47, COM_A14}, {"Simple 10", 49, COM_A14},
+  {"Triple 15", A8, COM_A14}, {"Double 15", 43, COM_A14},  {"Simple 15", 45, COM_A14},
+  {"Triple 2", A7, COM_A14},  {"Double 2", 41, COM_A14},   {"Simple 2", 39, COM_A14},
+  {"25 (Double)", A6, COM_A14},
+  {"Triple 13", A11, COM_A14}, {"Double 13", A4, COM_A14}, {"Simple 13", A5, COM_A14},
 
-  // === Common A1 ===
-  {"Triple 8", A11, COM_A1},  {"Double 8", A4, COM_A1},  {"Simple 8", A5, COM_A1},
-  {"Triple 14", A9, COM_A1}, {"Double 14", 47, COM_A1}, {"Simple 14", 49, COM_A1},
-  {"Triple 9", A8, COM_A1},  {"Double 9", 43, COM_A1},   {"Simple 9", 45, COM_A1},
-  {"Triple 11", A10, COM_A1}, {"Double 11", 51, COM_A1}, {"Simple 11", 53, COM_A1},
-  {"Triple 12", A7, COM_A1}, {"Double 12", 41, COM_A1},  {"Simple 12", 39, COM_A1},
+  // === Common A12 ===
+  {"Triple 8", A11, COM_A12},  {"Double 8", A4, COM_A12},  {"Simple 8", A5, COM_A12},
+  {"Triple 14", A9, COM_A12}, {"Double 14", 47, COM_A12}, {"Simple 14", 49, COM_A12},
+  {"Triple 9", A8, COM_A12},  {"Double 9", 43, COM_A12},   {"Simple 9", 45, COM_A12},
+  {"Triple 11", A10, COM_A12}, {"Double 11", 51, COM_A12}, {"Simple 11", 53, COM_A12},
+  {"Triple 12", A7, COM_A12}, {"Double 12", 41, COM_A12},  {"Simple 12", 39, COM_A12},
 
-  // === Common A2 ===
-  {"Triple 5", A11, COM_A2},  {"Double 5", A4, COM_A2},  {"Simple 5", A5, COM_A2},
-  {"Triple 20", A10, COM_A2}, {"Double 20", 51, COM_A2}, {"Simple 20", 53, COM_A2},
-  {"Triple 1", A9, COM_A2},  {"Double 1", 47, COM_A2},  {"Simple 1", 49, COM_A2},
-  {"Triple 18", A8, COM_A2}, {"Double 18", 43, COM_A2},  {"Simple 18", 45, COM_A2},
-  {"Triple 4", A7, COM_A2},  {"Double 4", 41, COM_A2},
-  {"25 (Simple)", A6, COM_A2},
-  {"Simple 4", 39, COM_A2}
+  // === Common A13 ===
+  {"Triple 5", A11, COM_A13},  {"Double 5", A4, COM_A13},  {"Simple 5", A5, COM_A13},
+  {"Triple 20", A10, COM_A13}, {"Double 20", 51, COM_A13}, {"Simple 20", 53, COM_A13},
+  {"Triple 1", A9, COM_A13},  {"Double 1", 47, COM_A13},  {"Simple 1", 49, COM_A13},
+  {"Triple 18", A8, COM_A13}, {"Double 18", 43, COM_A13},  {"Simple 18", 45, COM_A13},
+  {"Triple 4", A7, COM_A13},  {"Double 4", 41, COM_A13},
+  {"25 (Simple)", A6, COM_A13},
+  {"Simple 4", 39, COM_A13}
 };
 
 void inicijalizirajMete() {


### PR DESCRIPTION
## Summary
- rename common pin constants to avoid confusion
- update detection tables to use the new names
- adjust documentation to match

## Testing
- `g++ -std=c++17 -I./src/modules -I./src/core -I. -fsyntax-only src/modules/detection.cpp` *(fails: avr/pgmspace.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68867d6b59448328882e9a8322c484b9