### PR TITLE
Show source of early dart throws

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -209,9 +209,12 @@ void loop() {
     }
     postaviZaruljice(stanjeZaruljica);
 
-    if (detektirajBacanjeBezIgre()) {
-      logPoruka("Bacena strelica prije odabira!");
-      svirajZvukNepostavljenaIgra();
+    {
+      String razlog = detektirajBacanjeBezIgre();
+      if (razlog != "") {
+        logPoruka("Bacena strelica prije odabira! (" + razlog + ")");
+        svirajZvukNepostavljenaIgra();
+      }
     }
 
     // ----- Pokretanje igre -----

--- a/src/modules/detection.cpp
+++ b/src/modules/detection.cpp
@@ -110,10 +110,11 @@ void detektirajPromasaj() {
   }
 }
 
-bool detektirajBacanjeBezIgre() {
+String detektirajBacanjeBezIgre() {
   // Provjera pogođene mete
-  if (scanForHit() != nullptr) {
-    return true;
+  const Meta* meta = scanForHit();
+  if (meta != nullptr) {
+    return String(meta->naziv);
   }
 
   // Provjera promašaja preko mikrofona
@@ -127,8 +128,8 @@ bool detektirajBacanjeBezIgre() {
 
   if (vrijednost > THRESHOLD_PROMASAJ && millis() - zadnjeVrijeme > 300) {
     zadnjeVrijeme = millis();
-    return true;
+    return String("MIC");
   }
 
-  return false;
+  return String("");
 }

--- a/src/modules/detection.h
+++ b/src/modules/detection.h
@@ -4,6 +4,7 @@
 void inicijalizirajMete();
 void detektirajPromasaj();
 String detektirajZonu();
-bool detektirajBacanjeBezIgre();
+// Returns reason for a pre-game throw ("MIC" for miss or field name)
+String detektirajBacanjeBezIgre();
 // Pozvati kada je detektirana ikakva radnja (tipka ili pogodak)
 void registrirajInterakciju();


### PR DESCRIPTION
## Summary
- expand detection API to return why an early throw was detected
- show whether the throw was from microphone or a target

## Testing
- `g++ -std=c++17 -c src/modules/detection.cpp -I. -Isrc/modules -Isrc/core` *(fails: `avr/pgmspace.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688691043ad88328bc066755214fe299