### PR TITLE
Add dartboard calibration example

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -94,3 +94,9 @@ The system is modular so new games and features can easily be added. It can be e
 ## ❗ Errors and signalling
 
 Errors can be reported with `signalGreska()`. While active, the **RESET** button LED blinks so the user knows to restart or check the system.
+
+---
+
+## 🛠️ Target calibration
+
+If the dartboard reports wrong targets after rewiring, upload `examples/calibration.ino` to the Arduino. Open the serial monitor at 9600 baud and hit different fields. The detected target name and the pin numbers that were triggered will be printed, helping verify pin assignments.

--- a/README.md
+++ b/README.md
@@ -102,3 +102,9 @@ Ovaj sustav je dizajniran modularno tako da je lako dodavati nove igre i funkcio
 
 Greške se mogu prijaviti funkcijom `signalGreska()`. Dok je greška aktivna, lampica tipke **RESET** blinka kako bi korisnik znao da treba ponovno pokrenuti igru ili pregledati sustav.
 
+---
+
+## 🛠️ Kalibracija meta
+
+Ako nakon izmjene ožičenja pikado ploča ne javlja ispravne mete, isprobajte pomoćni program `examples/calibration.ino`. Učitajte ga na Arduino, otvorite serijski monitor (9600 baud) i gađajte pojedina polja. Na serijskom monitoru ispisat će se naziv detektirane mete i brojevi pinova koji su aktivirani, što olakšava provjeru rasporeda pinova.
+

--- a/examples/calibration.ino
+++ b/examples/calibration.ino
@@ -1,0 +1,80 @@
+#include <Arduino.h>
+#include "src/core/config.h"
+
+struct Meta {
+  const char* naziv;
+  uint8_t pinAktivan;
+  uint8_t pinZajednicki;
+};
+
+const Meta mete[] = {
+  // === Common A15 ===
+  {"Triple 17", A7, COM_A15}, {"Double 17", A0, COM_A15}, {"Simple 17", A1, COM_A15},
+  {"Triple 3", A6, COM_A15},  {"Double 3", 51, COM_A15},  {"Simple 3", 53, COM_A15},
+  {"Triple 19", A5, COM_A15}, {"Double 19", 47, COM_A15}, {"Simple 19", 49, COM_A15},
+  {"Triple 7", A4, COM_A15},  {"Double 7", 43, COM_A15},  {"Simple 7", 45, COM_A15},
+  {"Triple 16", A3, COM_A15}, {"Double 16", 41, COM_A15}, {"Simple 16", 39, COM_A15},
+
+  // === Common A14 ===
+  {"Triple 6", A6, COM_A14},  {"Double 6", 51, COM_A14},  {"Simple 6", 53, COM_A14},
+  {"Triple 10", A5, COM_A14}, {"Double 10", 47, COM_A14}, {"Simple 10", 49, COM_A14},
+  {"Triple 15", A4, COM_A14}, {"Double 15", 43, COM_A14}, {"Simple 15", 45, COM_A14},
+  {"Triple 2", A3, COM_A14},  {"Double 2", 41, COM_A14},  {"Simple 2", 39, COM_A14},
+  {"25 (Double)", A2, COM_A14},
+  {"Triple 13", A7, COM_A14}, {"Double 13", A0, COM_A14}, {"Simple 13", A1, COM_A14},
+
+  // === Common A12 ===
+  {"Triple 8", A7, COM_A12},  {"Double 8", A0, COM_A12},  {"Simple 8", A1, COM_A12},
+  {"Triple 14", A5, COM_A12}, {"Double 14", 47, COM_A12}, {"Simple 14", 49, COM_A12},
+  {"Triple 9", A4, COM_A12},  {"Double 9", 43, COM_A12},  {"Simple 9", 45, COM_A12},
+  {"Triple 11", A6, COM_A12}, {"Double 11", 51, COM_A12}, {"Simple 11", 53, COM_A12},
+  {"Triple 12", A3, COM_A12}, {"Double 12", 41, COM_A12}, {"Simple 12", 39, COM_A12},
+
+  // === Common A13 ===
+  {"Triple 5", A7, COM_A13},  {"Double 5", A0, COM_A13},  {"Simple 5", A1, COM_A13},
+  {"Triple 20", A6, COM_A13}, {"Double 20", 51, COM_A13}, {"Simple 20", 53, COM_A13},
+  {"Triple 1", A5, COM_A13},  {"Double 1", 47, COM_A13},  {"Simple 1", 49, COM_A13},
+  {"Triple 18", A4, COM_A13}, {"Double 18", 43, COM_A13}, {"Simple 18", 45, COM_A13},
+  {"Triple 4", A3, COM_A13},  {"Double 4", 41, COM_A13},
+  {"25 (Simple)", A2, COM_A13},
+  {"Simple 4", 39, COM_A13}
+};
+
+void setup() {
+  Serial.begin(9600);
+  for (const auto& meta : mete) {
+    pinMode(meta.pinAktivan, INPUT_PULLUP);
+    pinMode(meta.pinZajednicki, INPUT_PULLUP);
+  }
+  Serial.println(F("Dartboard calibration - hit a target"));
+}
+
+static const Meta* scanForHit() {
+  for (const auto& meta : mete) {
+    pinMode(meta.pinZajednicki, OUTPUT);
+    digitalWrite(meta.pinZajednicki, LOW);
+    pinMode(meta.pinAktivan, INPUT_PULLUP);
+    if (digitalRead(meta.pinAktivan) == LOW) {
+      delay(300);
+      while (digitalRead(meta.pinAktivan) == LOW);
+      delay(300);
+      pinMode(meta.pinZajednicki, INPUT_PULLUP);
+      return &meta;
+    }
+    pinMode(meta.pinZajednicki, INPUT_PULLUP);
+  }
+  return nullptr;
+}
+
+void loop() {
+  const Meta* pogodjena = scanForHit();
+  if (pogodjena) {
+    Serial.print(pogodjena->naziv);
+    Serial.print(F(" | active="));
+    Serial.print(pogodjena->pinAktivan);
+    Serial.print(F(" com="));
+    Serial.println(pogodjena->pinZajednicki);
+    delay(500); // give some time to see output
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a new calibration sketch for checking dartboard pin mapping
- document calibration usage in both README files
- print active/common pin numbers when a dart is detected

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688699b4d7d48328ba293550d396ef38