### PR TITLE
Show pin info for early throws

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -209,9 +209,12 @@ void loop() {
     }
     postaviZaruljice(stanjeZaruljica);
 
-    if (detektirajBacanjeBezIgre()) {
-      logPoruka("Bacena strelica prije odabira!");
-      svirajZvukNepostavljenaIgra();
+    {
+      String razlog = detektirajBacanjeBezIgre();
+      if (razlog != "") {
+        logPoruka("Bacena strelica prije odabira! (" + razlog + ")");
+        svirajZvukNepostavljenaIgra();
+      }
     }
 
     // ----- Pokretanje igre -----

--- a/src/modules/detection.cpp
+++ b/src/modules/detection.cpp
@@ -11,6 +11,20 @@ struct Meta {
   uint8_t pinZajednicki;
 };
 
+// Helper to convert a pin number to a human readable label
+static String nazivPina(uint8_t pin) {
+  if (pin == COM_A15) return String("COM_A15");
+  if (pin == COM_A14) return String("COM_A14");
+  if (pin == COM_A12) return String("COM_A12");
+  if (pin == COM_A13) return String("COM_A13");
+
+  if (pin >= A0 && pin <= A15) {
+    return String("A") + String(pin - A0);
+  }
+
+  return String(pin);
+}
+
 // Definicija svih meta
 const Meta mete[] = {
   // === Common A15 ===
@@ -110,10 +124,11 @@ void detektirajPromasaj() {
   }
 }
 
-bool detektirajBacanjeBezIgre() {
+String detektirajBacanjeBezIgre() {
   // Provjera pogođene mete
-  if (scanForHit() != nullptr) {
-    return true;
+  const Meta* meta = scanForHit();
+  if (meta != nullptr) {
+    return nazivPina(meta->pinZajednicki) + " -- " + nazivPina(meta->pinAktivan);
   }
 
   // Provjera promašaja preko mikrofona
@@ -127,8 +142,8 @@ bool detektirajBacanjeBezIgre() {
 
   if (vrijednost > THRESHOLD_PROMASAJ && millis() - zadnjeVrijeme > 300) {
     zadnjeVrijeme = millis();
-    return true;
+    return String("MIC");
   }
 
-  return false;
+  return String("");
 }

--- a/src/modules/detection.h
+++ b/src/modules/detection.h
@@ -4,6 +4,7 @@
 void inicijalizirajMete();
 void detektirajPromasaj();
 String detektirajZonu();
-bool detektirajBacanjeBezIgre();
+// Returns reason for a pre-game throw: "MIC" or "COM_* -- pin"
+String detektirajBacanjeBezIgre();
 // Pozvati kada je detektirana ikakva radnja (tipka ili pogodak)
 void registrirajInterakciju();


### PR DESCRIPTION
## Summary
- display which COM and sensor pins triggered an early dart throw

## Testing
- `g++ -std=c++17 -c src/modules/detection.cpp -I. -Isrc/modules -Isrc/core` *(fails: `avr/pgmspace.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688691043ad88328bc066755214fe299