### PR TITLE
Remove diacritics from code strings

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -56,7 +56,7 @@ void osvjeziZaruljiceIgra() {
     stanjeZaruljica[idxIgraca] = true;
   }
 
-  // Treperi lampica NEW_PLAYER dok se čekaju izbačene strelice
+  // Treperi lampica NEW_PLAYER dok se cekaju izbacene strelice
   if (cekanjeNovogIgraca) {
     unsigned long sada = millis();
     if (sada - zadnjeBlinkanje > 500) {
@@ -68,11 +68,11 @@ void osvjeziZaruljiceIgra() {
     stanjeZaruljica[IGRA_NEW_PLAYER] = false;
   }
 
-  // Prikaži odabrane DOUBLE IN/OUT opcije
+  // Prikazi odabrane DOUBLE IN/OUT opcije
   stanjeZaruljica[OSTALO_IN_CUTTHROAT] = DOUBLE_IN;
   stanjeZaruljica[OSTALO_OUT_TEAM] = DOUBLE_OUT;
 
-  // Ako je aktivna greška, blinkaj RESET lampicom
+  // Ako je aktivna greska, blinkaj RESET lampicom
   azurirajGresku();
   if (greskaAktivna()) {
     stanjeZaruljica[IGRA_RESET] = greskaBlinkStanje();
@@ -131,10 +131,10 @@ void setup() {
   inicijalizirajDisplay();
   inicijalizirajZvuk();
 
-  logPoruka("Dobrodošli!");
+  logPoruka("Dobrodosli!");
   svirajUvodnuMelodiju();
 
-  // Test žaruljica
+  // Test zaruljica
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 18; j++) stanjeZaruljica[j] = i % 2;
     postaviZaruljice(stanjeZaruljica);
@@ -241,7 +241,7 @@ void loop() {
     igraZavrsena = false;
     svirajImeIgraca(trenutniIgrac);
 
-    // Glavna igračka petlja
+    // Glavna igracka petlja
     while (!igraZavrsena) {
       ocitajTipke();
       if (biloKojaTipkaStisnuta()) registrirajInterakciju();
@@ -280,7 +280,7 @@ void loop() {
       delay(10);
     }
 
-    // Čekaj da korisnik pokrene novu igru
+    // Cekaj da korisnik pokrene novu igru
     while (igraZavrsena) {
       ocitajTipke();
       if (biloKojaTipkaStisnuta()) registrirajInterakciju();

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <Arduino.h>
 
-// Zajednički pinovi
-// Novi raspored zajedničkih pinova nakon prenamjene ploče
-constexpr uint8_t COM_A15 = A15;  // bijela žica
-constexpr uint8_t COM_A14 = A14;  // crna žica
+// Zajednicki pinovi
+// Novi raspored zajednickih pinova nakon prenamjene ploce
+constexpr uint8_t COM_A15 = A15;  // bijela zica
+constexpr uint8_t COM_A14 = A14;  // crna zica
 constexpr uint8_t COM_A12 = A12;
 constexpr uint8_t COM_A13 = A13;
 

--- a/src/games/game_301.cpp
+++ b/src/games/game_301.cpp
@@ -19,7 +19,7 @@ void inicijalizirajIgru_301() {
         igraci[i].prethodniBodovi = 301;
     }
     trenutniIgrac = 0;
-    logPoruka("Igra 301 započinje!");
+    logPoruka("Igra 301 zapocinje!");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -42,7 +42,7 @@ void obradiPogodak_301(const String& nazivMete) {
 
     int bodoviNakonPogotka = igrac.bodovi - vrijednost;
 
-    String poruka = "Pogođeno: " + nazivMete + " (" + String(vrijednost) + " bodova)";
+    String poruka = "Pogodeno: " + nazivMete + " (" + String(vrijednost) + " bodova)";
     logPoruka(poruka);
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
@@ -60,7 +60,7 @@ void obradiPogodak_301(const String& nazivMete) {
                 logPoruka(igrac.ime + " je pobijedio!");
                 zavrsiIgru();
             } else {
-                logPoruka("Završetak mora biti s Double!");
+                logPoruka("Zavrsetak mora biti s Double!");
                 igrac.bodovi = igrac.prethodniBodovi;
                 krajPoteza();
             }

--- a/src/games/game_3inline.cpp
+++ b/src/games/game_3inline.cpp
@@ -4,7 +4,7 @@
 #include "../core/config.h"
 #include "../modules/scoreboard.h"
 
-static bool pogodci[6][21]; // [igrač][broj 1-20], indeks 0 se ne koristi
+static bool pogodci[6][21]; // [igrac][broj 1-20], indeks 0 se ne koristi
 static uint8_t najduljiNiz[6];
 
 static int izracunajNiz(uint8_t igrac) {
@@ -30,7 +30,7 @@ void inicijalizirajIgru_3inline() {
         prikaziBodove(i, 0);
     }
     trenutniIgrac = 0;
-    logPoruka("Igra 3-in-line započinje!");
+    logPoruka("Igra 3-in-line zapocinje!");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
 }
 
@@ -48,7 +48,7 @@ void obradiPogodak_3inline(const String& nazivMete) {
     }
 
     if (broj < 1 || broj > 20) {
-        logPoruka("Nevažeći broj: " + String(broj));
+        logPoruka("Nevazeci broj: " + String(broj));
         sljedeciIgrac_3inline();
         return;
     }
@@ -59,7 +59,7 @@ void obradiPogodak_3inline(const String& nazivMete) {
         pogodci[trenutniIgrac][broj] = true;
         logPoruka(igrac.ime + " je pogodio broj " + String(broj));
     } else {
-        logPoruka("Broj " + String(broj) + " je već pogođen.");
+        logPoruka("Broj " + String(broj) + " je vec pogoden.");
     }
 
     int niz = izracunajNiz(trenutniIgrac);

--- a/src/games/game_501.cpp
+++ b/src/games/game_501.cpp
@@ -19,7 +19,7 @@ void inicijalizirajIgru_501() {
         igraci[i].prethodniBodovi = 501;
     }
     trenutniIgrac = 0;
-    logPoruka("Igra 501 započinje!");
+    logPoruka("Igra 501 zapocinje!");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -42,7 +42,7 @@ void obradiPogodak_501(const String& nazivMete) {
 
     int bodoviNakonPogotka = igrac.bodovi - vrijednost;
 
-    String poruka = "Pogođeno: " + nazivMete + " (" + String(vrijednost) + " bodova)";
+    String poruka = "Pogodeno: " + nazivMete + " (" + String(vrijednost) + " bodova)";
     logPoruka(poruka);
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
@@ -60,7 +60,7 @@ void obradiPogodak_501(const String& nazivMete) {
                 logPoruka(igrac.ime + " je pobijedio!");
                 zavrsiIgru();
             } else {
-                logPoruka("Završetak mora biti s Double!");
+                logPoruka("Zavrsetak mora biti s Double!");
                 igrac.bodovi = igrac.prethodniBodovi;
                 krajPoteza();
             }

--- a/src/games/game_701.cpp
+++ b/src/games/game_701.cpp
@@ -19,7 +19,7 @@ void inicijalizirajIgru_701() {
         igraci[i].prethodniBodovi = 701;
     }
     trenutniIgrac = 0;
-    logPoruka("Igra 701 započinje!");
+    logPoruka("Igra 701 zapocinje!");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -42,7 +42,7 @@ void obradiPogodak_701(const String& nazivMete) {
 
     int bodoviNakonPogotka = igrac.bodovi - vrijednost;
 
-    String poruka = "Pogođeno: " + nazivMete + " (" + String(vrijednost) + " bodova)";
+    String poruka = "Pogodeno: " + nazivMete + " (" + String(vrijednost) + " bodova)";
     logPoruka(poruka);
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
@@ -60,7 +60,7 @@ void obradiPogodak_701(const String& nazivMete) {
                 logPoruka(igrac.ime + " je pobijedio!");
                 zavrsiIgru();
             } else {
-                logPoruka("Završetak mora biti s Double!");
+                logPoruka("Zavrsetak mora biti s Double!");
                 igrac.bodovi = igrac.prethodniBodovi;
                 krajPoteza();
             }

--- a/src/games/game_cricket.cpp
+++ b/src/games/game_cricket.cpp
@@ -5,7 +5,7 @@
 #include "../modules/scoreboard.h"
 
 const int BROJEVI[7] = {15, 16, 17, 18, 19, 20, 25}; // validni brojevi
-static int pogodci[6][7];   // [igrač][broj index]
+static int pogodci[6][7];   // [igrac][broj index]
 static int bodoviCricket[6];
 
 void inicijalizirajIgru_cricket() {
@@ -15,8 +15,8 @@ void inicijalizirajIgru_cricket() {
         igraci[i].bodovi = 0;
     }
     trenutniIgrac = 0;
-    logPoruka("Igra CRICKET započinje!");
-    logPoruka("Pogađaj brojeve 15–20 i bull (25).");
+    logPoruka("Igra CRICKET zapocinje!");
+    logPoruka("Pogadaj brojeve 15–20 i bull (25).");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -55,7 +55,7 @@ void obradiPogodak_cricket(const String& nazivMete) {
 
     int idx = indeksBroja(broj);
     if (idx == -1) {
-        logPoruka("Broj " + String(broj) + " nije važeći u Cricketu.");
+        logPoruka("Broj " + String(broj) + " nije vazeci u Cricketu.");
         sljedeciIgrac_cricket();
         return;
     }
@@ -71,18 +71,18 @@ void obradiPogodak_cricket(const String& nazivMete) {
         if (!sviZatvorili(idx)) {
             bodoviCricket[trenutniIgrac] += BROJEVI[idx] * visak;
             igraci[trenutniIgrac].bodovi = bodoviCricket[trenutniIgrac];
-            logPoruka("Višak pogodaka! +" + String(BROJEVI[idx] * visak) +
+            logPoruka("Visak pogodaka! +" + String(BROJEVI[idx] * visak) +
                            " bodova. Ukupno: " + String(bodoviCricket[trenutniIgrac]));
             prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
         } else {
-            logPoruka("Broj je već zatvoren za sve – nema bodova.");
+            logPoruka("Broj je vec zatvoren za sve – nema bodova.");
         }
     } else if (p > pogodakaPrije) {
-        logPoruka("Zabilježeno " + String(mnozitelj) + " pogodaka broja " + String(broj) +
+        logPoruka("Zabiljezeno " + String(mnozitelj) + " pogodaka broja " + String(broj) +
                        " (sada ukupno: " + String(p) + ")");
     }
 
-    // Provjera je li sve zatvoreno kod ovog igrača
+    // Provjera je li sve zatvoreno kod ovog igraca
     bool sveZatvoreno = true;
     for (int i = 0; i < 7; i++) {
         if (pogodci[trenutniIgrac][i] < 3) {
@@ -101,7 +101,7 @@ void obradiPogodak_cricket(const String& nazivMete) {
             }
         }
         if (vodi) {
-            logPoruka("Igrač " + igraci[trenutniIgrac].ime + " je zatvorio sve brojeve i vodi u bodovima!");
+            logPoruka("Igrac " + igraci[trenutniIgrac].ime + " je zatvorio sve brojeve i vodi u bodovima!");
             logPoruka("POBJEDA!");
             zavrsiIgru();
             return;

--- a/src/games/game_hangman.cpp
+++ b/src/games/game_hangman.cpp
@@ -5,8 +5,8 @@
 #include "../modules/scoreboard.h"
 
 bool pogodjeniBrojevi[21];       // 1–20
-int greske[6];                  // broj grešaka po igraču
-int bodoviHangman[6];           // bodovi po igraču
+int greske[6];                  // broj gresaka po igracu
+int bodoviHangman[6];           // bodovi po igracu
 const int MAX_GRESAKA = 6;
 
 void inicijalizirajIgru_hangman() {
@@ -17,9 +17,9 @@ void inicijalizirajIgru_hangman() {
         igraci[i].bodovi = 0;
     }
     trenutniIgrac = 0;
-    logPoruka("Igra HANGMAN započinje!");
+    logPoruka("Igra HANGMAN zapocinje!");
     logPoruka("Pogodi brojeve 1–20 bez ponavljanja.");
-    logPoruka("Svaki igrač ima najviše 6 grešaka.");
+    logPoruka("Svaki igrac ima najvise 6 gresaka.");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -49,11 +49,11 @@ void obradiPogodak_hangman(const String& nazivMete) {
 
     if (pogodjeniBrojevi[broj]) {
         greske[trenutniIgrac]++;
-        logPoruka("Već pogođeni broj – greška! (" + String(greske[trenutniIgrac]) + "/" + String(MAX_GRESAKA) + ")");
+        logPoruka("Vec pogodeni broj – greska! (" + String(greske[trenutniIgrac]) + "/" + String(MAX_GRESAKA) + ")");
 
         if (greske[trenutniIgrac] >= MAX_GRESAKA) {
-            logPoruka(igraci[trenutniIgrac].ime + " je izgubio (više od 6 grešaka)!");
-            // Opcionalno: provjeri je li ostao samo 1 igrač aktivan
+            logPoruka(igraci[trenutniIgrac].ime + " je izgubio (vise od 6 gresaka)!");
+            // Opcionalno: provjeri je li ostao samo 1 igrac aktivan
             return;
         }
     } else {
@@ -61,7 +61,7 @@ void obradiPogodak_hangman(const String& nazivMete) {
         int bodovi = broj * mnozitelj;
         bodoviHangman[trenutniIgrac] += bodovi;
         igraci[trenutniIgrac].bodovi = bodoviHangman[trenutniIgrac];
-        logPoruka("Pogođeno " + String(broj) + " × " + String(mnozitelj) +
+        logPoruka("Pogodeno " + String(broj) + " × " + String(mnozitelj) +
                        " = +" + String(bodovi) + " bodova (Ukupno: " + String(bodoviHangman[trenutniIgrac]) + ")");
         prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
     }
@@ -80,19 +80,19 @@ void sljedeciIgrac_hangman() {
         }
     }
 
-    logPoruka("Nema više aktivnih igrača. Kraj igre!");
-    // Prikaži rezultat
+    logPoruka("Nema vise aktivnih igraca. Kraj igre!");
+    // Prikazi rezultat
     int najvise = -1;
     int pobjednik = -1;
     for (int i = 0; i < brojIgraca; i++) {
-        logPoruka("Igrač " + String(i) + ": " + String(bodoviHangman[i]) + " bodova");
+        logPoruka("Igrac " + String(i) + ": " + String(bodoviHangman[i]) + " bodova");
         if (bodoviHangman[i] > najvise) {
             najvise = bodoviHangman[i];
             pobjednik = i;
         }
     }
     if (pobjednik != -1) {
-        logPoruka("Pobjednik je IGRAČ " + String(pobjednik) + "!");
+        logPoruka("Pobjednik je IGRAC " + String(pobjednik) + "!");
     }
     zavrsiIgru();
 }

--- a/src/games/game_roulette.cpp
+++ b/src/games/game_roulette.cpp
@@ -7,7 +7,7 @@
 
 static int runda = 1;
 static int strelica = 1;
-int ciljaniBroj[6];  // ciljani broj po igraču
+int ciljaniBroj[6];  // ciljani broj po igracu
 int bodoviRoulette[6];  // ukupni bodovi
 
 void inicijalizirajIgru_roulette() {
@@ -17,10 +17,10 @@ void inicijalizirajIgru_roulette() {
         ciljaniBroj[i] = random(1, 21);  // 1–20
         bodoviRoulette[i] = 0;
         igraci[i].bodovi = 0;
-        logPoruka("Igrač " + String(i) + " ciljani broj: " + String(ciljaniBroj[i]));
+        logPoruka("Igrac " + String(i) + " ciljani broj: " + String(ciljaniBroj[i]));
     }
     trenutniIgrac = 0;
-    logPoruka("Igra ROULETTE započinje!");
+    logPoruka("Igra ROULETTE zapocinje!");
     svirajZvukRouletteStart();
     logPoruka("Runda 1 – Na potezu: " + igraci[trenutniIgrac].ime);
     prikaziCilj(trenutniIgrac, ciljaniBroj[trenutniIgrac], 1500);
@@ -49,12 +49,12 @@ void obradiPogodak_roulette(const String& nazivMete) {
     if (broj == ciljaniBroj[trenutniIgrac]) {
         bodoviRoulette[trenutniIgrac] += broj * mnozitelj;
         igraci[trenutniIgrac].bodovi = bodoviRoulette[trenutniIgrac];
-        logPoruka("Pogođen vlastiti broj! +" + String(broj * mnozitelj) +
+        logPoruka("Pogoden vlastiti broj! +" + String(broj * mnozitelj) +
                        " bodova. Ukupno: " + String(bodoviRoulette[trenutniIgrac]));
         prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
         svirajZvukTargetHit();
     } else {
-        logPoruka("Promašaj – nije tvoj broj.");
+        logPoruka("Promasaj – nije tvoj broj.");
         svirajZvukPromasaja();
     }
 
@@ -74,13 +74,13 @@ void obradiPogodak_roulette(const String& nazivMete) {
                 int pobjednik = 0;
                 int najvise = bodoviRoulette[0];
                 for (int i = 0; i < brojIgraca; i++) {
-                    logPoruka("Igrač " + String(i) + ": " + String(bodoviRoulette[i]) + " bodova");
+                    logPoruka("Igrac " + String(i) + ": " + String(bodoviRoulette[i]) + " bodova");
                     if (bodoviRoulette[i] > najvise) {
                         najvise = bodoviRoulette[i];
                         pobjednik = i;
                     }
                 }
-                logPoruka("Pobjednik je IGRAČ " + String(pobjednik) + "!");
+                logPoruka("Pobjednik je IGRAC " + String(pobjednik) + "!");
                 zavrsiIgru();
                 return;
             }

--- a/src/games/game_shanghai.cpp
+++ b/src/games/game_shanghai.cpp
@@ -23,8 +23,8 @@ void inicijalizirajIgru_shanghai() {
         igraci[i].bodovi = 0;
     }
     trenutniIgrac = 0;
-    logPoruka("Igra SHANGHAI započinje!");
-    String msg = "Runda " + String(runda) + ": Pogađa se broj " + String(runda);
+    logPoruka("Igra SHANGHAI zapocinje!");
+    String msg = "Runda " + String(runda) + ": Pogada se broj " + String(runda);
     logPoruka(msg);
     prikaziCilj(trenutniIgrac, runda, 1500);
     najaviCiljaniBroj(runda);
@@ -51,7 +51,7 @@ void obradiPogodak_shanghai(const String& nazivMete) {
     }
 
     if (broj != runda) {
-        logPoruka("Promašaj! Važeći broj u ovoj rundi je " + String(runda));
+        logPoruka("Promasaj! Vazeci broj u ovoj rundi je " + String(runda));
         svirajZvukPromasaja();
     } else {
         bodoviPoIgracu[trenutniIgrac] += broj * mnozitelj;
@@ -63,7 +63,7 @@ void obradiPogodak_shanghai(const String& nazivMete) {
 
         svirajZvukTargetHit();
 
-        logPoruka("Pogođeno " + String(broj) + " × " + String(mnozitelj) +
+        logPoruka("Pogodeno " + String(broj) + " × " + String(mnozitelj) +
                        " = +" + String(broj * mnozitelj));
     }
 
@@ -77,12 +77,12 @@ void obradiPogodak_shanghai(const String& nazivMete) {
             logPoruka(igraci[trenutniIgrac].ime + " je napravio SHANGHAI i pobijedio!");
             svirajZvukShanghai();
             zavrsiIgru();
-            return; // završava igra
+            return; // zavrsava igra
         } else {
             svirajZvukTryAgain();
         }
 
-        // Reset za sljedećeg igrača
+        // Reset za sljedeceg igraca
         pogodjenoSimple[trenutniIgrac] = false;
         pogodjenoDouble[trenutniIgrac] = false;
         pogodjenoTriple[trenutniIgrac] = false;
@@ -109,7 +109,7 @@ void obradiPogodak_shanghai(const String& nazivMete) {
                 zavrsiIgru();
                 return;
             } else {
-                String msg = "Runda " + String(runda) + ": Pogađa se broj " + String(runda);
+                String msg = "Runda " + String(runda) + ": Pogada se broj " + String(runda);
                 logPoruka(msg);
                 prikaziCilj(trenutniIgrac, runda, 1500);
                 najaviCiljaniBroj(runda);
@@ -125,5 +125,5 @@ void resetirajIgru_shanghai() {
 }
 
 void sljedeciIgrac_shanghai() {
-    // Ne koristi se u ovoj igri jer je logika već u obradi
+    // Ne koristi se u ovoj igri jer je logika vec u obradi
 }

--- a/src/modules/buttons.cpp
+++ b/src/modules/buttons.cpp
@@ -1,7 +1,7 @@
 #include "buttons.h"
 
 // Pins 20 (SDA) and 21 (SCL) moraju ostati slobodni za I2C (LCD)
-// Novi raspored tipki nakon prilagodbe ploče
+// Novi raspored tipki nakon prilagodbe ploce
 const uint8_t pinoviTipki[BROJ_TIPKI] = {
   36, 34, 30, 40, 28, 38, 32, 42, 46, 44,  // IGRA / OPCIJE
   33, 31, 29, 27, 25, 23,                 // IGRACI
@@ -12,14 +12,14 @@ bool stanjaTipki[BROJ_TIPKI];
 
 void inicijalizirajTipke() {
   for (int i = 0; i < BROJ_TIPKI; i++) {
-    pinMode(pinoviTipki[i], INPUT_PULLUP);  // ako koristiš tipke na masu
+    pinMode(pinoviTipki[i], INPUT_PULLUP);  // ako koristis tipke na masu
     stanjaTipki[i] = false;
   }
 }
 
 void ocitajTipke() {
   for (int i = 0; i < BROJ_TIPKI; i++) {
-    bool trenutno = digitalRead(pinoviTipki[i]) == LOW;  // LOW znači stisnuta
+    bool trenutno = digitalRead(pinoviTipki[i]) == LOW;  // LOW znaci stisnuta
     stanjaTipki[i] = trenutno;
   }
 }

--- a/src/modules/detection.cpp
+++ b/src/modules/detection.cpp
@@ -112,7 +112,7 @@ void detektirajPromasaj() {
   int vrijednost = zbroj / 3;
 
   if (vrijednost > THRESHOLD_PROMASAJ && millis() - zadnjeVrijeme > 300) {
-    logPoruka("Promašaj detektiran!");
+    logPoruka("Promasaj detektiran!");
     svirajZvukPromasaja();
     registrirajInterakciju();
     brojStrelica++;
@@ -124,13 +124,13 @@ void detektirajPromasaj() {
 }
 
 String detektirajBacanjeBezIgre() {
-  // Provjera pogođene mete
+  // Provjera pogodene mete
   const Meta* meta = scanForHit();
   if (meta != nullptr) {
     return nazivPina(meta->pinZajednicki) + " -- " + nazivPina(meta->pinAktivan);
   }
 
-  // Provjera promašaja preko mikrofona
+  // Provjera promasaja preko mikrofona
   static unsigned long zadnjeVrijeme = 0;
   int zbroj = 0;
   for (int i = 0; i < 3; i++) {

--- a/src/modules/melodies.h
+++ b/src/modules/melodies.h
@@ -9,9 +9,9 @@ void svirajZvukPobjede();
 void svirajZvukTipke();
 void svirajZvukNepostavljenaIgra();
 void svirajZvukBust();
-// Pusti MP3 datoteku sa snimljenim imenom igrača (0-5)
+// Pusti MP3 datoteku sa snimljenim imenom igraca (0-5)
 void svirajImeIgraca(uint8_t index);
-// Reproduciraj najavu pogođene mete
+// Reproduciraj najavu pogodene mete
 void svirajZvukMete(const String& nazivMete);
 void svirajZvukRouletteStart();
 void najaviCiljaniBroj(int broj);

--- a/src/modules/scoreboard.h
+++ b/src/modules/scoreboard.h
@@ -6,7 +6,7 @@ void prikaziBodove(uint8_t igrac, int bodovi);
 void osvjeziSveBodove();
 // Postavlja sve module na prikaz "---"
 void ocistiDisplay();
-// Privremeno prikaži ciljani broj na displayu igraca
+// Privremeno prikazi ciljani broj na displayu igraca
 void prikaziCilj(uint8_t igrac, int broj, unsigned long trajanjeMs);
 // Gasi sve segmente na svim modulima
 void ugasiDisplay();

--- a/src/modules/zaruljice.cpp
+++ b/src/modules/zaruljice.cpp
@@ -1,6 +1,6 @@
 #include "zaruljice.h"
 
-// Prilagodi ove pinove prema stvarnom ožičenju
+// Prilagodi ove pinove prema stvarnom ozicenju
 const int PIN_DATA = 5;
 const int PIN_CLK  = 6;
 const int PIN_LATCH = 7;

--- a/src/modules/zaruljice.h
+++ b/src/modules/zaruljice.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <Arduino.h>
 
-// Indeksi žaruljica odgovaraju vrijednostima enum-a Tipka (0-17)
+// Indeksi zaruljica odgovaraju vrijednostima enum-a Tipka (0-17)
 void inicijalizirajZaruljice();
 void postaviZaruljice(bool stanja[18]);


### PR DESCRIPTION
## Summary
- strip Croatian diacritics so LCD can render messages

## Testing
- `grep -R "[čžšđ]" PIKADO.ino src | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_688886a3e27083289dac003efe5e7296