### PR TITLE
Fix LED wiring map

### DIFF
--- a/docs/CONNECTIONS_AND_MP3.md
+++ b/docs/CONNECTIONS_AND_MP3.md
@@ -22,6 +22,29 @@ Note: pins **20** (SDA) and **21** (SCL) are reserved for the LCD I2C bus and mu
 | 3   | CLOCK |
 | 4   | LATCH |
 
+LED outputs are connected in the following order:
+
+| Output | Connected LED |
+|--------|---------------|
+| Chip1 OUT1 | Cricket |
+| Chip1 OUT2 | 3-in-LINE |
+| Chip1 OUT3 | NEW PLAYER |
+| Chip1 OUT4 | Hangman |
+| Chip1 OUT5 | Roulette |
+| Chip1 OUT6 | 701 |
+| Chip1 OUT7 | Shanghai |
+| Chip1 OUT8 | RESET |
+| Chip2 OUT1 | Player 4 |
+| Chip2 OUT2 | Player 3 |
+| Chip2 OUT3 | Player 2 |
+| Chip2 OUT4 | 501 |
+| Chip2 OUT5 | Double IN |
+| Chip2 OUT6 | Double OUT |
+| Chip2 OUT7 | Player 1 |
+| Chip2 OUT8 | Player 6 |
+| Chip3 OUT1 | Player 5 |
+| Chip3 OUT2 | 301 |
+
 ### MAX7219 display
 
 | Pin | Function |

--- a/src/modules/zaruljice.cpp
+++ b/src/modules/zaruljice.cpp
@@ -9,12 +9,36 @@ void inicijalizirajZaruljice() {
   pinMode(PIN_LED_LATCH, OUTPUT);
 }
 
+// Mapping from enum Tipka index to shift register output bit
+// Indices 0-7 -> first UCN5821, 8-15 -> second, 16+ -> third
+static const uint8_t LED_MAP[18] = {
+  17, // IGRA_301         -> chip3 OUT2
+  11, // IGRA_501         -> chip2 OUT4
+   6, // IGRA_SHANGHAI    -> chip1 OUT7
+   3, // IGRA_HANGMAN     -> chip1 OUT4
+   4, // IGRA_ROULETTE    -> chip1 OUT5
+   5, // IGRA_701         -> chip1 OUT6
+   0, // IGRA_CRICKET     -> chip1 OUT1
+   1, // IGRA_3INLINE     -> chip1 OUT2
+   2, // IGRA_NEW_PLAYER  -> chip1 OUT3
+   7, // IGRA_RESET       -> chip1 OUT8
+  14, // IGRAC_1          -> chip2 OUT7
+  10, // IGRAC_2          -> chip2 OUT3
+   9, // IGRAC_3          -> chip2 OUT2
+   8, // IGRAC_4          -> chip2 OUT1
+  16, // IGRAC_5          -> chip3 OUT1
+  15, // IGRAC_6          -> chip2 OUT8
+  13, // OSTALO_OUT_TEAM  -> chip2 OUT6 (Double OUT)
+  12  // OSTALO_IN_CUTTHROAT -> chip2 OUT5 (Double IN)
+};
+
 void postaviZaruljice(bool stanja[18]) {
   byte bajtovi[3] = {0};
 
   for (int i = 0; i < 18; i++) {
     if (stanja[i]) {
-      bajtovi[i / 8] |= (1 << (7 - (i % 8))); // MSB first
+      uint8_t bit = LED_MAP[i];
+      bajtovi[bit / 8] |= (1 << (7 - (bit % 8))); // MSB first
     }
   }
 

--- a/src/modules/zaruljice.h
+++ b/src/modules/zaruljice.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Arduino.h>
 
-// Indeksi zaruljica odgovaraju vrijednostima enum-a Tipka (0-17)
+// Funkcija prima polje stanja po redoslijedu enum-a Tipka (0-17)
+// te ih mapira na odgovarajuce izlaze UCN5821 registri
 void inicijalizirajZaruljice();
 void postaviZaruljice(bool stanja[18]);


### PR DESCRIPTION
## Summary
- map LED states to real UCN5821 outputs
- describe the wiring order in the connections doc

## Testing
- `avr-g++ -c -DF_CPU=16000000UL -mmcu=atmega2560 -I. -Isrc -Isrc/modules -Isrc/core -I./src/games -include Arduino.h src/modules/zaruljice.cpp -o /tmp/zaruljice.o` *(fails: fatal error: binary.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6888bc967fdc832894c366223a7b226d