### PR TITLE
Improve startup prompts and selection flow

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -168,8 +168,7 @@ void setup() {
     testMode();
   }
 
-  logPoruka("Odaberi igru.");
-  logPoruka("Izaberi igrace.");
+  logPoruka("Odaberi igru i igraca.");
 }
 
 void loop() {
@@ -186,18 +185,34 @@ void loop() {
     for (int i = IGRA_301; i <= IGRA_3INLINE; i++) {
       if (tipkaStisnuta(i)) {
         odabranaIgra = i;
-        String msg = "Odabrana igra: " + nazivIgre(i); logPoruka(msg);
-        porukaStartPrikazana = false;
+        String msg = "Odabrana igra: " + nazivIgre(i);
+        logPoruka(msg);
         svirajZvukTipke();
+        delay(2000);
+        if (odabraniBrojIgraca == -1) {
+          logPoruka("Odaberi igraca.");
+          porukaStartPrikazana = false;
+        } else {
+          logPoruka("Pritisni NEW PLAYER za start.");
+          porukaStartPrikazana = true;
+        }
       }
     }
 
     for (int i = IGRAC_1; i <= IGRAC_6; i++) {
       if (tipkaStisnuta(i)) {
         odabraniBrojIgraca = i - IGRAC_1 + 1;
-        String msg = "Odabrano igraca: " + String(odabraniBrojIgraca); logPoruka(msg);
-        porukaStartPrikazana = false;
+        String msg = "Odabrano igraca: " + String(odabraniBrojIgraca);
+        logPoruka(msg);
         svirajZvukTipke();
+        delay(2000);
+        if (odabranaIgra == -1) {
+          logPoruka("Odaberi igru.");
+          porukaStartPrikazana = false;
+        } else {
+          logPoruka("Pritisni NEW PLAYER za start.");
+          porukaStartPrikazana = true;
+        }
       }
     }
 
@@ -245,7 +260,7 @@ void loop() {
     }
 
     if (!porukaStartPrikazana && odabranaIgra != -1 && odabraniBrojIgraca != -1) {
-      logPoruka("Pritisni NEW PLAYER za pocetak");
+      logPoruka("Pritisni NEW PLAYER za start.");
       porukaStartPrikazana = true;
     }
 


### PR DESCRIPTION
## Summary
- show single prompt to select game and player
- confirm game or player selections for 2 seconds
- update instruction text to use "Pritisni NEW PLAYER za start"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888bf8cfba48328a74d8ff0333f8a4c