### PR TITLE
Auto-disable Double IN after entry

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -77,7 +77,7 @@ A detailed list of connections is in [CONNECTIONS_AND_MP3.md](docs/CONNECTIONS_A
 
 1. After uploading, open the **Serial Monitor at 9600 baud**
 2. Choose the game using the buttons
-3. For **301** and **501**, you can then press the **DOUBLE IN** and/or **DOUBLE OUT** buttons. Their LEDs will stay on and the rule applies for the whole game. Pressing them during a game has no effect – you must *RESET* to choose again.
+3. For **301** and **501**, you can then press the **DOUBLE IN** and/or **DOUBLE OUT** buttons. The LEDs indicate the active rules. The **DOUBLE IN** LED will turn off automatically once all players have opened with a Double, while **DOUBLE OUT** stays active until the end of the game. Pressing these buttons during a game has no effect – you must *RESET* to choose again.
 4. Then select the number of players
 5. LEDs show the current selections
 6. The game starts automatically

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ Detaljan popis priključaka nalazi se u [POVEZIVANJE_I_MP3.md](docs/POVEZIVANJE_
 1. Nakon učitavanja, otvori **Serial Monitor na 9600 baud**
 2. Odaberi igru pomoću tipki
 3. Za igre **301** i **501** nakon toga možete pritisnuti tipke
-   **DOUBLE IN** i/ili **DOUBLE OUT**. Lampice tih tipki ostat će upaljene i
-   pravilo će vrijediti tijekom cijele igre. Pritiskom ovih tipki za vrijeme
-   igre ništa se neće promijeniti – tek nakon *RESET* opcije moguće je ponovno
-   birati igru i dodatne funkcije.
+   **DOUBLE IN** i/ili **DOUBLE OUT**. Lampice prikazuju aktivna pravila.
+   Lampica **DOUBLE IN** automatski se gasi nakon što svi igrači uđu u igru
+   pogođenim Double poljem, dok **DOUBLE OUT** ostaje aktivan do kraja igre.
+   Pritiskom ovih tipki za vrijeme igre ništa se ne mijenja – tek nakon
+   *RESET* opcije moguće je ponovno birati igru i dodatne funkcije.
 4. Zatim odaberite broj igrača
 5. LED žaruljice će pokazati trenutne odabire
 6. Igra započinje automatski

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -29,9 +29,18 @@ void inicijalizirajIgrace(int broj) {
         igraci[i].ime = "Igrac " + String(i + 1);
         igraci[i].bodovi = 0;
         igraci[i].prethodniBodovi = 0;
+        igraci[i].jeAktiviran = false;
     }
     trenutniIgrac = 0;
     ocistiDisplay();
+}
+
+void provjeriDoubleInZavrsen() {
+    if (!DOUBLE_IN) return;
+    for (int i = 0; i < brojIgraca; i++) {
+        if (!igraci[i].jeAktiviran) return;
+    }
+    DOUBLE_IN = false;
 }
 
 void sljedeciIgrac() {

--- a/src/core/game.h
+++ b/src/core/game.h
@@ -40,3 +40,7 @@ void sljedeciIgrac();
 // Centralne funkcije:
 void pokreniAktivnuIgru();
 void obradiPogodak(const String& nazivMete);
+
+// Ako je DOUBLE IN ukljucen, provjerava jesu li svi igraci vec ostvarili
+// pocetni Double. U tom slucaju gasi opciju DOUBLE IN (i pripadajucu lampicu).
+void provjeriDoubleInZavrsen();

--- a/src/games/game_301.cpp
+++ b/src/games/game_301.cpp
@@ -36,6 +36,7 @@ void obradiPogodak_301(const String& nazivMete) {
             return;
         }
         igrac.jeAktiviran = true;
+        provjeriDoubleInZavrsen();
     }
 
     igrac.prethodniBodovi = igrac.bodovi;

--- a/src/games/game_501.cpp
+++ b/src/games/game_501.cpp
@@ -36,6 +36,7 @@ void obradiPogodak_501(const String& nazivMete) {
             return;
         }
         igrac.jeAktiviran = true;
+        provjeriDoubleInZavrsen();
     }
 
     igrac.prethodniBodovi = igrac.bodovi;

--- a/src/games/game_701.cpp
+++ b/src/games/game_701.cpp
@@ -36,6 +36,7 @@ void obradiPogodak_701(const String& nazivMete) {
             return;
         }
         igrac.jeAktiviran = true;
+        provjeriDoubleInZavrsen();
     }
 
     igrac.prethodniBodovi = igrac.bodovi;


### PR DESCRIPTION
## Summary
- reset player activation state when starting a game
- add helper `provjeriDoubleInZavrsen` to disable DOUBLE IN when all players entered
- call helper from 301/501/701 games
- document new behavior in README files

## Testing
- `git commit -m "Auto-disable Double IN light after all players"`


------
https://chatgpt.com/codex/tasks/task_e_6888c19aa5008328a1d444d80e5a8740