### PR TITLE
Shorten LCD messages

### DIFF
--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -52,7 +52,7 @@ void sljedeciIgrac() {
 void krajPoteza() {
     cekanjeNovogIgraca = true;
     brojStrelica = 0;
-    logPoruka("Izvadi strelice i pritisni NEW PLAYER.");
+    logPoruka("Izvadi strelice i stisni NEW.");
     svirajZvukVadenja();
 }
 
@@ -85,7 +85,7 @@ void obradiPogodak(const String& nazivMete) {
 void zavrsiIgru() {
     igraZavrsena = true;
     svirajZvukPobjede();
-    logPoruka("Igra zavrsena. Pritisni tipku igre za novu.");
+    logPoruka("Igra gotova. Odaberi novu igru.");
 }
 
 void resetirajAktivnuIgru() {

--- a/src/games/game_301.cpp
+++ b/src/games/game_301.cpp
@@ -31,7 +31,7 @@ void obradiPogodak_301(const String& nazivMete) {
     // DOUBLE IN provjera
     if (DOUBLE_IN && !igrac.jeAktiviran) {
         if (!nazivMete.startsWith("Double")) {
-            logPoruka("Double IN: pogodak ne vrijedi jer nije Double.");
+            logPoruka("Double IN: treba Double.");
             krajPoteza();
             return;
         }
@@ -47,7 +47,7 @@ void obradiPogodak_301(const String& nazivMete) {
     logPoruka(poruka);
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
-        logPoruka("Bust! Prelazak preko 0 nije dozvoljen.");
+        logPoruka("Bust! Prelazak preko 0 nije OK.");
         svirajZvukBust();
         igrac.bodovi = igrac.prethodniBodovi;
         prikaziBodove(trenutniIgrac, igrac.bodovi);

--- a/src/games/game_3inline.cpp
+++ b/src/games/game_3inline.cpp
@@ -40,7 +40,7 @@ void obradiPogodak_3inline(const String& nazivMete) {
     if (nazivMete.startsWith("Triple ") || nazivMete.startsWith("Double ") || nazivMete.startsWith("Simple ")) {
         broj = nazivMete.substring(nazivMete.indexOf(' ') + 1).toInt();
     } else if (nazivMete.indexOf("25") != -1) {
-        logPoruka("Pogodak u 25 ne vrijedi za 3-in-line.");
+        logPoruka("25 ne vrijedi za 3-in-line.");
         sljedeciIgrac_3inline();
         return;
     } else {

--- a/src/games/game_501.cpp
+++ b/src/games/game_501.cpp
@@ -31,7 +31,7 @@ void obradiPogodak_501(const String& nazivMete) {
     // DOUBLE IN provjera
     if (DOUBLE_IN && !igrac.jeAktiviran) {
         if (!nazivMete.startsWith("Double")) {
-            logPoruka("Double IN: pogodak ne vrijedi jer nije Double.");
+            logPoruka("Double IN: treba Double.");
             krajPoteza();
             return;
         }
@@ -47,7 +47,7 @@ void obradiPogodak_501(const String& nazivMete) {
     logPoruka(poruka);
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
-        logPoruka("Bust! Prelazak preko 0 nije dozvoljen.");
+        logPoruka("Bust! Prelazak preko 0 nije OK.");
         svirajZvukBust();
         igrac.bodovi = igrac.prethodniBodovi;
         prikaziBodove(trenutniIgrac, igrac.bodovi);

--- a/src/games/game_701.cpp
+++ b/src/games/game_701.cpp
@@ -31,7 +31,7 @@ void obradiPogodak_701(const String& nazivMete) {
     // DOUBLE IN provjera
     if (DOUBLE_IN && !igrac.jeAktiviran) {
         if (!nazivMete.startsWith("Double")) {
-            logPoruka("Double IN: pogodak ne vrijedi jer nije Double.");
+            logPoruka("Double IN: treba Double.");
             krajPoteza();
             return;
         }
@@ -47,7 +47,7 @@ void obradiPogodak_701(const String& nazivMete) {
     logPoruka(poruka);
 
     if (BOUNCE_OUT && bodoviNakonPogotka < 0) {
-        logPoruka("Bust! Prelazak preko 0 nije dozvoljen.");
+        logPoruka("Bust! Prelazak preko 0 nije OK.");
         svirajZvukBust();
         igrac.bodovi = igrac.prethodniBodovi;
         prikaziBodove(trenutniIgrac, igrac.bodovi);

--- a/src/games/game_cricket.cpp
+++ b/src/games/game_cricket.cpp
@@ -16,7 +16,7 @@ void inicijalizirajIgru_cricket() {
     }
     trenutniIgrac = 0;
     logPoruka("Igra CRICKET zapocinje!");
-    logPoruka("Pogadaj brojeve 15–20 i bull (25).");
+    logPoruka("Pogodi 15-20 i bull (25).");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -71,15 +71,15 @@ void obradiPogodak_cricket(const String& nazivMete) {
         if (!sviZatvorili(idx)) {
             bodoviCricket[trenutniIgrac] += BROJEVI[idx] * visak;
             igraci[trenutniIgrac].bodovi = bodoviCricket[trenutniIgrac];
-            logPoruka("Visak pogodaka! +" + String(BROJEVI[idx] * visak) +
-                           " bodova. Ukupno: " + String(bodoviCricket[trenutniIgrac]));
+            logPoruka(String("Visak +") + String(BROJEVI[idx] * visak) +
+                       " bod. Uk:" + String(bodoviCricket[trenutniIgrac]));
             prikaziBodove(trenutniIgrac, igraci[trenutniIgrac].bodovi);
         } else {
-            logPoruka("Broj je vec zatvoren za sve – nema bodova.");
+            logPoruka("Broj zatvoren - nema bodova.");
         }
     } else if (p > pogodakaPrije) {
-        logPoruka("Zabiljezeno " + String(mnozitelj) + " pogodaka broja " + String(broj) +
-                       " (sada ukupno: " + String(p) + ")");
+        logPoruka(String("Dodano ") + String(mnozitelj) + "x" + String(broj) +
+                       " (uk " + String(p) + ")");
     }
 
     // Provjera je li sve zatvoreno kod ovog igraca

--- a/src/games/game_hangman.cpp
+++ b/src/games/game_hangman.cpp
@@ -18,8 +18,8 @@ void inicijalizirajIgru_hangman() {
     }
     trenutniIgrac = 0;
     logPoruka("Igra HANGMAN zapocinje!");
-    logPoruka("Pogodi brojeve 1–20 bez ponavljanja.");
-    logPoruka("Svaki igrac ima najvise 6 gresaka.");
+    logPoruka("Pogodi 1-20 bez ponavljanja.");
+    logPoruka("Svaki igrac ima do 6 gresaka.");
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     osvjeziSveBodove();
 }
@@ -80,7 +80,7 @@ void sljedeciIgrac_hangman() {
         }
     }
 
-    logPoruka("Nema vise aktivnih igraca. Kraj igre!");
+    logPoruka("Nema aktivnih igraca, kraj!");
     // Prikazi rezultat
     int najvise = -1;
     int pobjednik = -1;


### PR DESCRIPTION
## Summary
- trim long in-game messages to 32 chars or less
- tweak Cricket messages for brevity

## Testing
- `python3 - <<'EOF'
import re, os
threshold=32
msgs=[]
for root, _, files in os.walk('.'):
    for f in files:
        if f.endswith('.cpp') or f.endswith('.ino'):
            path=os.path.join(root,f)
            with open(path,encoding='utf-8') as fh:
                for i,l in enumerate(fh,1):
                    m=re.search(r'logPoruka\("([^"]*)"\)',l)
                    if m and len(m.group(1))>threshold:
                        msgs.append((len(m.group(1)),path,i))
print(len(msgs))
EOF

------
https://chatgpt.com/codex/tasks/task_e_6888c443e6648328aba1bf01fdb54619