### PR TITLE
Fix LED shift chain order

### DIFF
--- a/docs/CONNECTIONS_AND_MP3.md
+++ b/docs/CONNECTIONS_AND_MP3.md
@@ -24,6 +24,10 @@ Note: pins **20** (SDA) and **21** (SCL) are reserved for the LCD I2C bus and mu
 
 LED outputs are connected in the following order:
 
+> **Note**: When sending data to the daisy-chained UCN5821 shift registers,
+> transmit the byte for **Chip3** first, then **Chip2**, and finally **Chip1** so
+> that each chip receives the correct bits.
+
 | Output | Connected LED |
 |--------|---------------|
 | Chip1 OUT1 | Cricket |

--- a/src/modules/zaruljice.cpp
+++ b/src/modules/zaruljice.cpp
@@ -43,7 +43,9 @@ void postaviZaruljice(bool stanja[18]) {
   }
 
   digitalWrite(PIN_LED_LATCH, LOW);
-  for (int i = 0; i < 3; i++) {
+  // Send bytes in reverse order so the last chip in the chain receives its
+  // data first (Chip3 -> Chip2 -> Chip1)
+  for (int i = 2; i >= 0; i--) {
     shiftOut(PIN_LED_DATA, PIN_LED_CLK, MSBFIRST, bajtovi[i]);
   }
   digitalWrite(PIN_LED_LATCH, HIGH);


### PR DESCRIPTION
## Summary
- send LED bytes in reverse order so Chip3 bits go first
- document correct chip order in `CONNECTIONS_AND_MP3.md`

## Testing
- `arduino-builder -verbose -compile -hardware /usr/share/arduino/hardware -tools /usr/bin -tools /usr/share/arduino-builder -libraries /usr/share/arduino/hardware/arduino/avr/libraries -libraries . -fqbn arduino:avr:mega -build-path /tmp/arduino_build PIKADO.ino` *(fails: missing device or architecture after '-mmcu=')*

------
https://chatgpt.com/codex/tasks/task_e_6888ce174920832897e2c75e8574d61a