### PR TITLE
Switch LED shift register to LSB first

### DIFF
--- a/docs/CONNECTIONS_AND_MP3.md
+++ b/docs/CONNECTIONS_AND_MP3.md
@@ -26,7 +26,9 @@ LED outputs are connected in the following order:
 
 > **Note**: When sending data to the daisy-chained UCN5821 shift registers,
 > transmit the byte for **Chip3** first, then **Chip2**, and finally **Chip1** so
-> that each chip receives the correct bits.
+> that each chip receives the correct bits. The firmware shifts data **LSB
+> first** because the board's wiring flips the order of outputs (OUT1 &harr;
+> OUT8).
 
 | Output | Connected LED |
 |--------|---------------|

--- a/src/modules/zaruljice.cpp
+++ b/src/modules/zaruljice.cpp
@@ -38,7 +38,9 @@ void postaviZaruljice(bool stanja[18]) {
   for (int i = 0; i < 18; i++) {
     if (stanja[i]) {
       uint8_t bit = LED_MAP[i];
-      bajtovi[bit / 8] |= (1 << (7 - (bit % 8))); // MSB first
+      // When shifting out LSB first, OUT1 corresponds to the least significant
+      // bit of each byte.
+      bajtovi[bit / 8] |= (1 << (bit % 8));
     }
   }
 
@@ -46,7 +48,7 @@ void postaviZaruljice(bool stanja[18]) {
   // Send bytes in reverse order so the last chip in the chain receives its
   // data first (Chip3 -> Chip2 -> Chip1)
   for (int i = 2; i >= 0; i--) {
-    shiftOut(PIN_LED_DATA, PIN_LED_CLK, MSBFIRST, bajtovi[i]);
+    shiftOut(PIN_LED_DATA, PIN_LED_CLK, LSBFIRST, bajtovi[i]);
   }
   digitalWrite(PIN_LED_LATCH, HIGH);
 }


### PR DESCRIPTION
## Summary
- shift LED data out using LSBFIRST
- document the new bit order in `CONNECTIONS_AND_MP3.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888d4d0dd488328afc1e7914bef8048