### PR TITLE
Enable test mode in main loop

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -55,6 +55,7 @@ static bool idleBlink = false;
 // Test mode helpers - declared in test.h
 bool resetHeld(unsigned long ms);
 void testMode();
+void provjeriTestMod();
 
 bool biloKojaTipkaStisnuta();
 void registrirajInterakciju();
@@ -173,6 +174,7 @@ void setup() {
 
 void loop() {
   ocitajTipke();
+  provjeriTestMod();
   bool stisnuta = biloKojaTipkaStisnuta();
   if (stisnuta) {
     registrirajInterakciju();
@@ -293,6 +295,7 @@ void loop() {
     // Glavna igracka petlja
     while (!igraZavrsena) {
       ocitajTipke();
+      provjeriTestMod();
       if (biloKojaTipkaStisnuta()) registrirajInterakciju();
       azurirajNeaktivnost();
       osvjeziZaruljiceIgra();
@@ -333,6 +336,7 @@ void loop() {
     // Cekaj da korisnik pokrene novu igru
     while (igraZavrsena) {
       ocitajTipke();
+      provjeriTestMod();
       if (biloKojaTipkaStisnuta()) registrirajInterakciju();
       azurirajNeaktivnost();
       osvjeziZaruljiceIgra();

--- a/src/modules/test.cpp
+++ b/src/modules/test.cpp
@@ -64,3 +64,17 @@ void testMode() {
     delay(10);
   }
 }
+
+static unsigned long testHoldStart = 0;
+
+void provjeriTestMod() {
+  if (tipkaStisnuta(IGRA_RESET)) {
+    if (testHoldStart == 0) testHoldStart = millis();
+    if (millis() - testHoldStart >= 5000) {
+      testHoldStart = 0;
+      testMode();
+    }
+  } else {
+    testHoldStart = 0;
+  }
+}

--- a/src/modules/test.h
+++ b/src/modules/test.h
@@ -6,3 +6,6 @@ bool resetHeld(unsigned long ms);
 
 // Ulazi u testni mod dok se ne pritisne RESET 5 sekundi ili ne ugasi uredjaj
 void testMode();
+
+// Provjerava drzi li se RESET dovoljno dugo tijekom rada programa
+void provjeriTestMod();


### PR DESCRIPTION
## Summary
- expose `provjeriTestMod` in test module
- call `provjeriTestMod` in the main loop so RESET held for 5s enters test mode

## Testing
- `g++ -std=c++17 -x c++ -I. -Isrc/modules -Isrc/core -c PIKADO.ino` *(fails: `avr/pgmspace.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888d73d3f5483288febf231d6861ce5