### PR TITLE
Refresh scoreboard on player switch

### DIFF
--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -47,6 +47,8 @@ void sljedeciIgrac() {
     trenutniIgrac = (trenutniIgrac + 1) % brojIgraca;
     logPoruka("Na potezu: " + igraci[trenutniIgrac].ime);
     svirajImeIgraca(trenutniIgrac);
+    // Refresh the scoreboard so the new player's score is immediately visible
+    osvjeziSveBodove();
 }
 
 void krajPoteza() {


### PR DESCRIPTION
## Summary
- refresh MAX7219 display each time the active player changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a183ab36883289918561c4f9b7121