### PR TITLE
Fix LED shift orientation

### DIFF
--- a/docs/CONNECTIONS_AND_MP3.md
+++ b/docs/CONNECTIONS_AND_MP3.md
@@ -26,8 +26,8 @@ LED outputs are connected in the following order:
 
 > **Note**: When sending data to the daisy-chained UCN5821 shift registers,
 > transmit the byte for **Chip3** first, then **Chip2**, and finally **Chip1** so
-> that each chip receives the correct bits. The firmware shifts data **LSB
-> first** because the board's wiring flips the order of outputs (OUT1 &harr;
+> that each chip receives the correct bits. The firmware shifts data **MSB
+> first** because the board wiring inverts each chip's outputs (OUT1 &harr;
 > OUT8).
 
 | Output | Connected LED |

--- a/src/modules/zaruljice.cpp
+++ b/src/modules/zaruljice.cpp
@@ -38,9 +38,10 @@ void postaviZaruljice(bool stanja[18]) {
   for (int i = 0; i < 18; i++) {
     if (stanja[i]) {
       uint8_t bit = LED_MAP[i];
-      // When shifting out LSB first, OUT1 corresponds to the least significant
-      // bit of each byte.
-      bajtovi[bit / 8] |= (1 << (bit % 8));
+      // When shifting out MSB first, OUT1 maps to the most significant bit
+      // of each byte. The board inverts outputs (OUT1 ↔ OUT8), so we
+      // mirror the bit position within each byte.
+      bajtovi[bit / 8] |= (1 << (7 - (bit % 8)));
     }
   }
 
@@ -48,7 +49,7 @@ void postaviZaruljice(bool stanja[18]) {
   // Send bytes in reverse order so the last chip in the chain receives its
   // data first (Chip3 -> Chip2 -> Chip1)
   for (int i = 2; i >= 0; i--) {
-    shiftOut(PIN_LED_DATA, PIN_LED_CLK, LSBFIRST, bajtovi[i]);
+    shiftOut(PIN_LED_DATA, PIN_LED_CLK, MSBFIRST, bajtovi[i]);
   }
   digitalWrite(PIN_LED_LATCH, HIGH);
 }


### PR DESCRIPTION
## Summary
- mirror bit positions and shift MSB first when driving LEDs
- clarify MSB-first requirement in connection docs

## Testing
- `g++ -std=c++11 -fsyntax-only src/modules/zaruljice.cpp -I src/core -I src/modules -I .` *(fails: avr/pgmspace.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_688a1a583ea48328a2656a15ecf540af