### PR TITLE
Fix MAX7219 scan limit

### DIFF
--- a/src/modules/scoreboard.cpp
+++ b/src/modules/scoreboard.cpp
@@ -10,6 +10,7 @@ static LedControl lc(PIN_SCORE_DIN, PIN_SCORE_CLK, PIN_SCORE_CS, BROJ_DISPLEJA);
 void inicijalizirajDisplay() {
     for (uint8_t i = 0; i < BROJ_DISPLEJA; i++) {
         lc.shutdown(i, false);
+        lc.setScanLimit(i, 2); // each module uses only 3 digits
         lc.setIntensity(i, 8);
         lc.clearDisplay(i);
     }


### PR DESCRIPTION
## Summary
- set scan limit for MAX7219 modules

## Testing
- `arduino-cli compile --fqbn arduino:avr:mega PIKADO.ino` *(fails: platform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a35b04d048328a3d936b51757036c