### PR TITLE
Fix startup LED states and blink controls

### DIFF
--- a/PIKADO.ino
+++ b/PIKADO.ino
@@ -29,6 +29,7 @@ int indeksIgraca = 0;
 bool prvaTipkaPritisnuta = false;
 bool igraPokrenuta = false;
 bool porukaStartPrikazana = false;
+bool startBlink = false;
 
 static String nazivIgre(int tipka) {
   switch (tipka) {
@@ -282,9 +283,14 @@ void loop() {
         zadnjeMijenjanje = sada;
         indeksIgre = (indeksIgre + 1) % 8;
         indeksIgraca = (indeksIgraca + 1) % 6;
+        startBlink = !startBlink;
       }
       stanjeZaruljica[redoslijedIgara[indeksIgre]] = true;
       stanjeZaruljica[redoslijedIgraca[indeksIgraca]] = true;
+      stanjeZaruljica[IGRA_NEW_PLAYER] = startBlink;
+      stanjeZaruljica[IGRA_RESET] = startBlink;
+      stanjeZaruljica[OSTALO_IN_CUTTHROAT] = startBlink;
+      stanjeZaruljica[OSTALO_OUT_TEAM] = startBlink;
     } else {
       if (odabranaIgra != -1) {
         stanjeZaruljica[odabranaIgra] = true;

--- a/src/modules/zaruljice.cpp
+++ b/src/modules/zaruljice.cpp
@@ -7,6 +7,13 @@ void inicijalizirajZaruljice() {
   pinMode(PIN_LED_DATA, OUTPUT);
   pinMode(PIN_LED_CLK, OUTPUT);
   pinMode(PIN_LED_LATCH, OUTPUT);
+
+  // Clear all outputs so LEDs don't light up randomly on power-up
+  digitalWrite(PIN_LED_LATCH, LOW);
+  for (int i = 0; i < 3; i++) {
+    shiftOut(PIN_LED_DATA, PIN_LED_CLK, MSBFIRST, 0);
+  }
+  digitalWrite(PIN_LED_LATCH, HIGH);
 }
 
 // Mapping from enum Tipka index to shift register output bit


### PR DESCRIPTION
## Summary
- clear LED shift registers on init so random LEDs don't light at boot
- blink control LEDs before the game is chosen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a37e6b5a8832889e62b6fc2475a11